### PR TITLE
Type checks + less verbose syntax

### DIFF
--- a/generate_col_ops.py
+++ b/generate_col_ops.py
@@ -73,7 +73,7 @@ def generate_fn_decl(
 
     if len(op.context_kwargs) > 0:
         context_kwarg_annotation = {
-            "partition_by": "Col | ColName | Iterable[Col | ColName]",
+            "partition_by": "Col | ColName | str | Iterable[Col | ColName | str]",
             "arrange": "ColExpr | Iterable[ColExpr]",
             "filter": "ColExpr[Bool] | Iterable[ColExpr[Bool]]",
         }

--- a/src/pydiverse/transform/_internal/pipe/functions.py
+++ b/src/pydiverse/transform/_internal/pipe/functions.py
@@ -105,7 +105,7 @@ def coalesce(arg: ColExpr, *args: ColExpr) -> ColExpr:
 
 def count(
     *,
-    partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+    partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
     filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
 ) -> ColExpr[Int]:
     """
@@ -117,7 +117,7 @@ def count(
 
 def dense_rank(
     *,
-    partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+    partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
     arrange: ColExpr | Iterable[ColExpr],
 ) -> ColExpr[Int]:
     """
@@ -312,7 +312,7 @@ def sum(arg: ColExpr, *args: ColExpr) -> ColExpr:
 
 def rank(
     *,
-    partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+    partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
     arrange: ColExpr | Iterable[ColExpr],
 ) -> ColExpr[Int]:
     """
@@ -356,7 +356,7 @@ def rank(
 
 def row_number(
     *,
-    partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+    partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
     arrange: ColExpr | Iterable[ColExpr] | None = None,
 ) -> ColExpr[Int]:
     """

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -162,12 +162,13 @@ class Table:
         :doc:`/database_testing`.
         """
 
-        errors.check_arg_type(
-            pl.DataFrame | pl.LazyFrame | pd.DataFrame | sqa.Table | str | dict,
-            "Table.__init__",
-            "resource",
-            resource,
-        )
+        if not isinstance(resource, TableImpl):
+            errors.check_arg_type(
+                pl.DataFrame | pl.LazyFrame | pd.DataFrame | sqa.Table | str | dict,
+                "Table.__init__",
+                "resource",
+                resource,
+            )
         errors.check_arg_type(Target | None, "Table.__init__", "backend", backend)
         errors.check_arg_type(str | None, "Table.__init__", "name", name)
 

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -5,9 +5,13 @@ import dataclasses
 import inspect
 from collections.abc import Callable, Iterable
 from html import escape
-from typing import Any
 from uuid import UUID
 
+import pandas as pd
+import polars as pl
+import sqlalchemy as sqa
+
+from pydiverse.transform._internal import errors
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.backend.targets import Target
 from pydiverse.transform._internal.pipe.pipeable import Pipeable
@@ -32,7 +36,11 @@ class Table:
     """
 
     def __init__(
-        self, resource: Any, backend: Target | None = None, *, name: str | None = None
+        self,
+        resource: pl.DataFrame | pl.LazyFrame | pd.DataFrame | sqa.Table | str | dict,
+        backend: Target | None = None,
+        *,
+        name: str | None = None,
     ):
         """
         Creates a new table.
@@ -153,6 +161,15 @@ class Table:
         database. For more information on how to set up a connection, see
         :doc:`/database_testing`.
         """
+
+        errors.check_arg_type(
+            pl.DataFrame | pl.LazyFrame | pd.DataFrame | sqa.Table | str | dict,
+            "Table.__init__",
+            "resource",
+            resource,
+        )
+        errors.check_arg_type(Target | None, "Table.__init__", "backend", backend)
+        errors.check_arg_type(str | None, "Table.__init__", "name", name)
 
         self._ast: AstNode = TableImpl.from_resource(resource, backend, name=name)
         self._cache = Cache(

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -320,11 +320,11 @@ def show_query(table: Table) -> Pipeable:
 
 
 @overload
-def select(*cols: Col | ColName) -> Pipeable: ...
+def select(*cols: Col | ColName | str) -> Pipeable: ...
 
 
 @verb
-def select(table: Table, *cols: Col | ColName) -> Pipeable:
+def select(table: Table, *cols: Col | ColName | str) -> Pipeable:
     """
     Selects a subset of columns.
 
@@ -348,7 +348,8 @@ def select(table: Table, *cols: Col | ColName) -> Pipeable:
     └─────┘
     """
 
-    errors.check_vararg_type(Col | ColName, "select", *cols)
+    errors.check_vararg_type(Col | ColName | str, "select", *cols)
+    cols = [ColName(col) if isinstance(col, str) else col for col in cols]
 
     new = copy.copy(table)
     new._ast = Select(table._ast, [preprocess_arg(col, table) for col in cols])
@@ -360,11 +361,11 @@ def select(table: Table, *cols: Col | ColName) -> Pipeable:
 
 
 @overload
-def drop(*cols: Col | ColName) -> Pipeable: ...
+def drop(*cols: Col | ColName | str) -> Pipeable: ...
 
 
 @verb
-def drop(table: Table, *cols: Col | ColName) -> Pipeable:
+def drop(table: Table, *cols: Col | ColName | str) -> Pipeable:
     """
     Removes a subset of the columns.
 
@@ -387,7 +388,8 @@ def drop(table: Table, *cols: Col | ColName) -> Pipeable:
     │ __**_ │
     └───────┘
     """
-    errors.check_vararg_type(Col | ColName, "drop", *cols)
+    errors.check_vararg_type(Col | ColName | str, "drop", *cols)
+    cols = [ColName(col) if isinstance(col, str) else col for col in cols]
 
     dropped_uuids = {preprocess_arg(col, table)._uuid for col in cols}
     return table >> select(
@@ -662,11 +664,11 @@ def arrange(table: Table, *order_by: ColExpr) -> Pipeable:
 
 
 @overload
-def group_by(table: Table, *cols: Col | ColName, add=False) -> Pipeable: ...
+def group_by(table: Table, *cols: Col | ColName | str, add=False) -> Pipeable: ...
 
 
 @verb
-def group_by(table: Table, *cols: Col | ColName, add=False) -> Pipeable:
+def group_by(table: Table, *cols: Col | ColName | str, add=False) -> Pipeable:
     """
     Add a grouping state to the table.
 
@@ -688,8 +690,9 @@ def group_by(table: Table, *cols: Col | ColName, add=False) -> Pipeable:
     if len(cols) == 0:
         return table
 
-    errors.check_vararg_type(Col | ColName, "group_by", *cols)
+    errors.check_vararg_type(Col | ColName | str, "group_by", *cols)
     errors.check_arg_type(bool, "group_by", "add", add)
+    cols = [ColName(col) if isinstance(col, str) else col for col in cols]
 
     new = copy.copy(table)
     new._ast = GroupBy(table._ast, [preprocess_arg(col, table) for col in cols], add)

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -337,7 +337,7 @@ class ColExpr(Generic[T]):
     def all(
         self: ColExpr[Bool],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Bool]:
         """Indicates whether every non-null value in a group is True."""
@@ -347,7 +347,7 @@ class ColExpr(Generic[T]):
     def any(
         self: ColExpr[Bool],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Bool]:
         """Indicates whether at least one value in a group is True."""
@@ -602,7 +602,7 @@ class ColExpr(Generic[T]):
     def count(
         self: ColExpr,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Int]:
         """
@@ -877,7 +877,7 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[Int],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Int]: ...
 
@@ -885,7 +885,7 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[Float],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Float]: ...
 
@@ -893,7 +893,7 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[Decimal],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Decimal]: ...
 
@@ -901,7 +901,7 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[String],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[String]: ...
 
@@ -909,7 +909,7 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[Datetime],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Datetime]: ...
 
@@ -917,14 +917,14 @@ class ColExpr(Generic[T]):
     def max(
         self: ColExpr[Date],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Date]: ...
 
     def max(
         self: ColExpr,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr:
         """Computes the maximum value in each group."""
@@ -935,7 +935,7 @@ class ColExpr(Generic[T]):
     def mean(
         self: ColExpr[Float],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Float]: ...
 
@@ -943,7 +943,7 @@ class ColExpr(Generic[T]):
     def mean(
         self: ColExpr[Decimal],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Decimal]: ...
 
@@ -951,14 +951,14 @@ class ColExpr(Generic[T]):
     def mean(
         self: ColExpr[Int],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Float]: ...
 
     def mean(
         self: ColExpr,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr:
         """Computes the average value in each group."""
@@ -969,7 +969,7 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[Int],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Int]: ...
 
@@ -977,7 +977,7 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[Float],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Float]: ...
 
@@ -985,7 +985,7 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[Decimal],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Decimal]: ...
 
@@ -993,7 +993,7 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[String],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[String]: ...
 
@@ -1001,7 +1001,7 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[Datetime],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Datetime]: ...
 
@@ -1009,14 +1009,14 @@ class ColExpr(Generic[T]):
     def min(
         self: ColExpr[Date],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Date]: ...
 
     def min(
         self: ColExpr,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr:
         """Computes the minimum value in each group."""
@@ -1264,7 +1264,7 @@ class ColExpr(Generic[T]):
         n: int,
         fill_value: ColExpr = None,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         arrange: ColExpr | Iterable[ColExpr] | None = None,
     ) -> ColExpr:
         """
@@ -1374,7 +1374,7 @@ class ColExpr(Generic[T]):
     def sum(
         self: ColExpr[Int],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Int]: ...
 
@@ -1382,7 +1382,7 @@ class ColExpr(Generic[T]):
     def sum(
         self: ColExpr[Float],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Float]: ...
 
@@ -1390,14 +1390,14 @@ class ColExpr(Generic[T]):
     def sum(
         self: ColExpr[Decimal],
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Decimal]: ...
 
     def sum(
         self: ColExpr,
         *,
-        partition_by: Col | ColName | Iterable[Col | ColName] | None = None,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr:
         """Computes the sum of values in each group."""
@@ -2473,10 +2473,19 @@ def wrap_literal(expr: Any, *, allow_markers=False) -> Any:
 
 def clean_kwargs(**kwargs) -> dict[str, list[ColExpr]]:
     kwargs = {
-        key: [val] if not isinstance(val, Iterable) else val
+        key: [val]
+        if not isinstance(val, Iterable) or isinstance(val, str)
+        else list(val)
         for key, val in kwargs.items()
         if val is not None
     }
+    if (partition_by := kwargs.get("partition_by")) is not None:
+        kwargs["partition_by"] = [
+            ColName(col) if isinstance(col, str) else col for col in partition_by
+        ]
     if (arrange := kwargs.get("arrange")) is not None:
-        kwargs["arrange"] = [Order.from_col_expr(ord) for ord in arrange]
+        kwargs["arrange"] = [
+            Order.from_col_expr(ColName(ord) if isinstance(ord, str) else ord)
+            for ord in arrange
+        ]
     return {key: [wrap_literal(val) for val in arr] for key, arr in kwargs.items()}

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -31,6 +31,17 @@ def test_join(df1, df2, how):
 
     assert_result_equal(
         (df1, df2),
+        lambda t, u: t >> join(u, on="col1", how=how),
+    )
+
+    assert_result_equal(
+        (df1, df2),
+        lambda t, u: t
+        >> join(u, on=["col1", t.col1.cast(pdt.Float64()) >= u.col3], how=how),
+    )
+
+    assert_result_equal(
+        (df1, df2),
         lambda t, u: t
         >> join(u, (t.col1 == u.col1) & (t.col1 == u.col2), how=how)
         >> mutate(l=t.col2.str.len())

--- a/tests/test_backend_equivalence/test_select.py
+++ b/tests/test_backend_equivalence/test_select.py
@@ -9,6 +9,7 @@ from tests.util import assert_result_equal
 def test_simple_select(df1):
     assert_result_equal(df1, lambda t: t >> select(t.col1))
     assert_result_equal(df1, lambda t: t >> select(t.col2))
+    assert_result_equal(df1, lambda t: t >> select("col1"))
 
 
 def test_reorder(df1):


### PR DESCRIPTION
We allow strings in the select / drop / join / group_by verbs and partition_by / arrange kwargs.