### PR TITLE
Fix many bugs related to column referencing and add new operations

### DIFF
--- a/docs/source/reference/operators/aggregation.rst
+++ b/docs/source/reference/operators/aggregation.rst
@@ -25,3 +25,4 @@ Aggregation functions take a ``partition_by`` and ``filter`` keyword argument. T
     mean
     min
     sum
+    str.join

--- a/docs/source/reference/operators/index.rst
+++ b/docs/source/reference/operators/index.rst
@@ -89,6 +89,7 @@ Expression methods
    min
    nulls_first
    nulls_last
+   prefix_sum
    rank
    round
    shift

--- a/docs/source/reference/operators/index.rst
+++ b/docs/source/reference/operators/index.rst
@@ -94,6 +94,7 @@ Expression methods
    shift
    str.contains
    str.ends_with
+   str.join
    str.len
    str.lower
    str.replace_all

--- a/docs/source/reference/operators/index.rst
+++ b/docs/source/reference/operators/index.rst
@@ -82,6 +82,7 @@ Expression methods
    is_not_nan
    is_not_null
    is_null
+   list.agg
    log
    map
    max

--- a/docs/source/reference/operators/list.rst
+++ b/docs/source/reference/operators/list.rst
@@ -1,0 +1,11 @@
+====
+List
+====
+
+.. currentmodule:: pydiverse.transform.ColExpr
+.. autosummary::
+    :toctree: _generated/
+    :nosignatures:
+    :template: short_title.rst
+
+    list.agg

--- a/docs/source/reference/operators/string.rst
+++ b/docs/source/reference/operators/string.rst
@@ -10,6 +10,7 @@ String
 
     str.contains
     str.ends_with
+    str.join
     str.len
     str.lower
     str.replace_all

--- a/docs/source/reference/operators/window.rst
+++ b/docs/source/reference/operators/window.rst
@@ -8,6 +8,7 @@ Window
     :nosignatures:
     :template: short_title.rst
 
+    prefix_sum
     shift
 
 .. currentmodule:: pydiverse.transform

--- a/generate_col_ops.py
+++ b/generate_col_ops.py
@@ -63,7 +63,7 @@ def generate_fn_decl(
         name
         + ": "
         + type_annotation(dtype, specialize_generic)
-        + (f" = {default_val}" if default_val is not ... else "")
+        + (f" = {repr(default_val)}" if default_val is not ... else "")
         for dtype, name, default_val in zip(
             sig.types, op.param_names, defaults, strict=True
         )

--- a/generate_col_ops.py
+++ b/generate_col_ops.py
@@ -17,7 +17,7 @@ COL_EXPR_PATH = "./src/pydiverse/transform/_internal/tree/col_expr.py"
 FNS_PATH = "./src/pydiverse/transform/_internal/pipe/functions.py"
 API_DOCS_PATH = "./docs/source/reference/operators/index.rst"
 
-NAMESPACES = ["str", "dt", "dur"]
+NAMESPACES = ["str", "dt", "dur", "list"]
 
 RVERSIONS = {
     "__add__",

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -78,3 +78,7 @@ with DuckDbImpl.impl_store.impl_manager as impl:
     @impl(ops.is_not_nan)
     def _is_not_nan(x):
         return ~sqa.func.isnan(x)
+
+    @impl(ops.str_join)
+    def _str_join(x, delim):
+        return sqa.func.string_agg(x, delim)

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -35,6 +35,7 @@ from pydiverse.transform._internal.tree.types import (
     Int16,
     Int32,
     Int64,
+    List,
     NullType,
     String,
     Uint8,
@@ -469,6 +470,8 @@ def pdt_type(pl_type: pl.DataType) -> Dtype:
         return Date()
     elif isinstance(pl_type, pl.Duration):
         return Duration()
+    elif isinstance(pl_type, pl.List):
+        return List()
     elif isinstance(pl_type, pl.Null):
         return NullType()
 
@@ -511,6 +514,8 @@ def polars_type(pdt_type: Dtype) -> pl.DataType:
         return pl.Date()
     elif pdt_type <= Duration():
         return pl.Duration()
+    elif pdt_type <= List():
+        return pl.List
     elif pdt_type <= NullType():
         return pl.Null()
 

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -48,6 +48,12 @@ from pydiverse.transform._internal.tree.types import (
 class PolarsImpl(TableImpl):
     def __init__(self, name: str, df: pl.DataFrame | pl.LazyFrame):
         self.df = df if isinstance(df, pl.LazyFrame) else df.lazy()
+        self.df = self.df.cast(
+            {
+                pl.Datetime("ns"): pl.Datetime("us"),
+                pl.Datetime("ms"): pl.Datetime("us"),
+            }
+        )
         super().__init__(
             name,
             {name: pdt_type(dtype) for name, dtype in df.collect_schema().items()},

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -748,3 +748,7 @@ with PolarsImpl.impl_store.impl_manager as impl:
     @impl(ops.pow, Int(), Int())
     def _pow(x, y):
         return x.cast(pl.Float64()) ** y
+
+    @impl(ops.str_join)
+    def _str_join(x, delim):
+        return x.str.join(delim)

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -751,4 +751,4 @@ with PolarsImpl.impl_store.impl_manager as impl:
 
     @impl(ops.str_join)
     def _str_join(x, delim):
-        return x.str.join(delim)
+        return x.str.join(pl.select(delim).item())

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -776,3 +776,7 @@ with PolarsImpl.impl_store.impl_manager as impl:
     @impl(ops.str_join)
     def _str_join(x, delim):
         return x.str.join(pl.select(delim).item())
+
+    @impl(ops.prefix_sum)
+    def _prefix_sum(x):
+        return x.cum_sum()

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -344,7 +344,7 @@ def compile_ast(
 
         predicates = split_join_cond(nd.on)
         right_df = right_df.rename(
-            {name: name + nd.suffix for name in right_df.columns}
+            {name: name + nd.suffix for name in right_df.collect_schema().names()}
         )
 
         # Do equality predicates separately because polars coalesces on them.

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -953,3 +953,7 @@ with SqlImpl.impl_store.impl_manager as impl:
     @impl(ops.coalesce)
     def _coalesce(*x):
         return sqa.func.coalesce(*x)
+
+    @impl(ops.str_join)
+    def _str_join(x, delim):
+        return sqa.func.aggregate_strings(x, delim)

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -747,7 +747,7 @@ def get_engine(nd: AstNode) -> sqa.Engine:
 
         if isinstance(nd, verbs.Join):
             right_engine = get_engine(nd.right)
-            if engine != right_engine:
+            if engine.url != right_engine.url:
                 raise NotImplementedError  # TODO: find some good error for this
 
     else:

--- a/src/pydiverse/transform/_internal/backend/sqlite.py
+++ b/src/pydiverse/transform/_internal/backend/sqlite.py
@@ -41,6 +41,8 @@ class SqliteImpl(SqlImpl):
 
         elif cast.val.dtype() <= Datetime() and cast.target_type == Date():
             return sqa.type_coerce(sqa.func.date(compiled_val), sqa.Date())
+        elif cast.val.dtype() <= Date() and cast.target_type == Datetime():
+            return sqa.type_coerce(sqa.func.datetime(compiled_val), sqa.DateTime())
 
         elif cast.val.dtype() <= Float() and cast.target_type == String():
             return sqa.case(

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -15,7 +15,7 @@ from pydiverse.transform._internal.errors import NotSupportedError
 from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.ops.op import Ftype
 from pydiverse.transform._internal.tree.ast import AstNode
-from pydiverse.transform._internal.tree.col_expr import Col
+from pydiverse.transform._internal.tree.col_expr import Col, ColFn
 from pydiverse.transform._internal.tree.types import Dtype
 
 try:
@@ -145,6 +145,14 @@ def get_backend(nd: AstNode) -> type[TableImpl]:
         return get_backend(nd.child)
     assert isinstance(nd, TableImpl) and nd is not TableImpl
     return nd.__class__
+
+
+def split_join_cond(expr: ColFn) -> list[ColFn]:
+    assert isinstance(expr, ColFn)
+    if expr.op == ops.bool_and:
+        return split_join_cond(expr.args[0]) + split_join_cond(expr.args[1])
+    else:
+        return [expr]
 
 
 with TableImpl.impl_store.impl_manager as impl:

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -15,7 +15,7 @@ from pydiverse.transform._internal.errors import NotSupportedError
 from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.ops.op import Ftype
 from pydiverse.transform._internal.tree.ast import AstNode
-from pydiverse.transform._internal.tree.col_expr import Col, ColFn
+from pydiverse.transform._internal.tree.col_expr import Col, ColFn, LiteralCol
 from pydiverse.transform._internal.tree.types import Dtype
 
 try:
@@ -148,8 +148,10 @@ def get_backend(nd: AstNode) -> type[TableImpl]:
 
 
 def split_join_cond(expr: ColFn) -> list[ColFn]:
-    assert isinstance(expr, ColFn)
-    if expr.op == ops.bool_and:
+    assert isinstance(expr, ColFn | LiteralCol)
+    if isinstance(expr, LiteralCol):
+        return []
+    elif expr.op == ops.bool_and:
         return split_join_cond(expr.args[0]) + split_join_cond(expr.args[1])
     else:
         return [expr]

--- a/src/pydiverse/transform/_internal/ops/op.py
+++ b/src/pydiverse/transform/_internal/ops/op.py
@@ -18,7 +18,7 @@ class Ftype(enum.IntEnum):
 @dataclasses.dataclass(slots=True)
 class ContextKwarg:
     name: str
-    required: bool
+    required: bool = False
 
 
 class Operator:

--- a/src/pydiverse/transform/_internal/ops/op.py
+++ b/src/pydiverse/transform/_internal/ops/op.py
@@ -55,12 +55,26 @@ class Operator:
         generate_expr_method: bool = True,
         doc: str = "",
     ):
+        assert isinstance(name, str)
+        assert all(isinstance(sig, Signature) for sig in signatures)
+        assert isinstance(ftype, Ftype)
+        assert isinstance(doc, str)
+        assert isinstance(generate_expr_method, bool)
+        if isinstance(param_names, list):
+            assert all(isinstance(param, str) for param in param_names)
+        else:
+            assert param_names is None
+        if isinstance(context_kwargs, list):
+            assert all(isinstance(kwarg, ContextKwarg) for kwarg in context_kwargs)
+        else:
+            assert context_kwargs is None
+        assert isinstance(default_values, list | type(None))
+
         self.name = name
         self.ftype = ftype
         self.context_kwargs = context_kwargs if context_kwargs is not None else []
         self.generate_expr_method = generate_expr_method
 
-        assert all(isinstance(sig, Signature) for sig in signatures)
         self.signatures = signatures
         self.trie = SignatureTrie()
         assert len(signatures) > 0

--- a/src/pydiverse/transform/_internal/ops/ops/__init__.py
+++ b/src/pydiverse/transform/_internal/ops/ops/__init__.py
@@ -5,6 +5,7 @@ from .arithmetic import *
 from .comparison import *
 from .datetime import *
 from .horizontal import *
+from .list import *
 from .logical import *
 from .markers import *
 from .numeric import *

--- a/src/pydiverse/transform/_internal/ops/ops/aggregation.py
+++ b/src/pydiverse/transform/_internal/ops/ops/aggregation.py
@@ -10,6 +10,7 @@ from pydiverse.transform._internal.tree.types import (
     Decimal,
     Float,
     Int,
+    String,
 )
 
 
@@ -18,17 +19,24 @@ class Aggregation(Operator):
         self,
         name: str,
         *signatures: Signature,
+        context_kwargs=None,
+        param_names=None,
+        default_values=None,
         generate_expr_method: bool = True,
         doc: str = "",
     ):
+        if context_kwargs is None:
+            context_kwargs = [
+                ContextKwarg("partition_by", False),
+                ContextKwarg("filter", False),
+            ]
         super().__init__(
             name,
             *signatures,
             ftype=Ftype.AGGREGATE,
-            context_kwargs=[
-                ContextKwarg("partition_by", False),
-                ContextKwarg("filter", False),
-            ],
+            context_kwargs=context_kwargs,
+            param_names=param_names,
+            default_values=default_values,
             generate_expr_method=generate_expr_method,
             doc=doc,
         )
@@ -86,4 +94,21 @@ count_star = Aggregation(
     doc="""
 Returns the number of rows of the current table, like :code:`COUNT(*)` in SQL.
 """,
+)
+
+str_join = Aggregation(
+    "str.join",
+    Signature(String(), String(const=True), return_type=String()),
+    param_names=["self", "delimiter"],
+    default_values=[..., ""],
+    context_kwargs=[
+        ContextKwarg("partition_by"),
+        ContextKwarg("filter"),
+        ContextKwarg("arrange"),
+    ],
+    doc="""
+Concatenates all strings in a group to a single string.
+
+:param delimiter:
+    The string to insert between the elements.""",
 )

--- a/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
+++ b/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
@@ -18,6 +18,8 @@ add = Operator(
     *(Signature(dtype, dtype, return_type=dtype) for dtype in NUMERIC),
     Signature(String(), String(), return_type=String()),
     Signature(Duration(), Duration(), return_type=Duration()),
+    Signature(Datetime(), Duration(), return_type=Datetime()),
+    Signature(Duration(), Datetime(), return_type=Datetime()),
     doc="Addition +",
 )
 

--- a/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
+++ b/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
@@ -28,8 +28,6 @@ sub = Operator(
     *(Signature(dtype, dtype, return_type=dtype) for dtype in NUMERIC),
     Signature(Datetime(), Datetime(), return_type=Duration()),
     Signature(Date(), Date(), return_type=Duration()),
-    Signature(Datetime(), Date(), return_type=Duration()),
-    Signature(Date(), Datetime(), return_type=Duration()),
     doc="Subtraction -",
 )
 

--- a/src/pydiverse/transform/_internal/ops/ops/list.py
+++ b/src/pydiverse/transform/_internal/ops/ops/list.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydiverse.transform._internal.ops.op import ContextKwarg
+from pydiverse.transform._internal.ops.ops.aggregation import Aggregation
+from pydiverse.transform._internal.ops.signature import Signature
+from pydiverse.transform._internal.tree.types import D, List
+
+list_agg = Aggregation(
+    "list.agg",
+    Signature(D, return_type=List()),
+    context_kwargs=[
+        ContextKwarg("partition_by"),
+        ContextKwarg("arrange"),
+        ContextKwarg("filter"),
+    ],
+    doc="""
+Collect the elements of each group in a list.
+""",
+)

--- a/src/pydiverse/transform/_internal/ops/ops/window.py
+++ b/src/pydiverse/transform/_internal/ops/ops/window.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydiverse.transform._internal.ops.op import ContextKwarg, Ftype, Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import D, Int, Tvar
+from pydiverse.transform._internal.tree.types import NUMERIC, D, Int, Tvar
 
 
 class Window(Operator):
@@ -200,5 +200,15 @@ shape: (7, 3)
 │ null ┆ 1   ┆ 1   │
 │ 8    ┆ 4   ┆ 4   │
 └──────┴─────┴─────┘
+""",
+)
+
+prefix_sum = Window(
+    "prefix_sum",
+    *(Signature(dtype, return_type=dtype) for dtype in NUMERIC),
+    generate_expr_method=True,
+    arrange_required=False,
+    doc="""
+The sum of all preceding elements and the current element.
 """,
 )

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -319,6 +319,11 @@ class Cache:
                 for uid, name in self.uuid_to_name.items()
                 if name in selected_names
             }
+            self.name_to_uuid = {
+                name: uid
+                for name, uid in self.name_to_uuid.items()
+                if name in selected_names
+            }
 
         elif isinstance(vb, Rename):
             self.name_to_uuid = {

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -194,7 +194,7 @@ class Table:
         if name in ("__copy__", "__deepcopy__", "__setstate__", "__getstate__"):
             # for hasattr to work correctly on dunder methods
             raise AttributeError
-        if not self._cache.has_col(name):
+        if name not in self._cache.name_to_uuid:
             raise ValueError(
                 f"column `{name}` does not exist in table `{self._ast.name}`"
             )
@@ -335,7 +335,6 @@ class Cache:
                     name: self.all_cols[uid] for name, uid in self.name_to_uuid.items()
                 }
             else:
-                # Summarize
                 new_cols = {
                     self.uuid_to_name[col._uuid]: col for col in self.partition_by
                 }

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -346,8 +346,11 @@ class Cache:
         elif isinstance(vb, Rename):
             self._update(
                 new_cols=[
-                    (new_name if (new_name := vb.name_map.get(name)) else name, col)
-                    for name, col in self.name_to_uuid.items()
+                    (
+                        new_name if (new_name := vb.name_map.get(name)) else name,
+                        self.all_cols[uid],
+                    )
+                    for name, uid in self.name_to_uuid.items()
                 ]
             )
 

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -326,9 +326,7 @@ class Cache:
                 for name, uid in self.name_to_uuid.items()
             }
             self.uuid_to_name = self.uuid_to_name | {
-                uid: new_name
-                for name, uid in self.name_to_uuid.items()
-                if (new_name := vb.name_map.get(name))
+                uid: name for name, uid in self.name_to_uuid.items()
             }
 
         elif isinstance(vb, Mutate | Summarize):

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -330,9 +330,16 @@ class Cache:
             }
 
         elif isinstance(vb, Mutate | Summarize):
-            new_cols = {
-                name: self.all_cols[uid] for name, uid in self.name_to_uuid.items()
-            } | {
+            if isinstance(vb, Mutate):
+                new_cols = {
+                    name: self.all_cols[uid] for name, uid in self.name_to_uuid.items()
+                }
+            else:
+                # Summarize
+                new_cols = {
+                    self.uuid_to_name[col._uuid]: col for col in self.partition_by
+                }
+            new_cols |= {
                 name: Col(
                     name,
                     vb,

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -18,6 +18,7 @@ from pydiverse.transform._internal.tree.col_expr import (
     ColExpr,
     ColFn,
     ColName,
+    LiteralCol,
     Order,
     wrap_literal,
 )
@@ -1044,6 +1045,7 @@ def join(
                 left[expr] == right[expr] if isinstance(expr, str) else expr
                 for expr in on
             ),
+            LiteralCol(True),  # initial value
         )
 
     if left._cache.partition_by:
@@ -1198,6 +1200,21 @@ def full_join(
     return left >> join(
         right, on, "full", validate=validate, suffix=suffix, coalesce=coalesce
     )
+
+
+@verb
+def cross_join(
+    left: Table,
+    right: Table,
+    *,
+    suffix: str | None = None,
+    coalesce: bool = False,
+) -> Pipeable:
+    """
+    Alias for the :doc:`pydiverse.transform.join` verb with ``how="full"``.
+    """
+
+    return left >> full_join(right, on=[], suffix=suffix, coalesce=coalesce)
 
 
 @overload

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -912,7 +912,7 @@ def slice_head(table: Table, n: int, *, offset: int = 0) -> Pipeable:
 @overload
 def join(
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     how: Literal["inner", "left", "full"],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
@@ -925,7 +925,7 @@ def join(
 def join(
     left: Table,
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     how: Literal["inner", "left", "full"],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
@@ -1100,7 +1100,7 @@ def join(
 @overload
 def inner_join(
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
@@ -1112,7 +1112,7 @@ def inner_join(
 def inner_join(
     left: Table,
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
@@ -1130,7 +1130,7 @@ def inner_join(
 @overload
 def left_join(
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
@@ -1142,7 +1142,7 @@ def left_join(
 def left_join(
     left: Table,
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
@@ -1160,7 +1160,7 @@ def left_join(
 @overload
 def full_join(
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
@@ -1172,7 +1172,7 @@ def full_join(
 def full_join(
     left: Table,
     right: Table,
-    on: ColExpr[Bool] | str | list[ColExpr[bool] | str],
+    on: ColExpr[Bool] | str | list[ColExpr[Bool] | str],
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -1051,7 +1051,9 @@ def join(
     if suffix is None:
         suffix = "_right"
 
-    left_names = set(left._cache.name_to_uuid.keys())
+    left_names = set(left._cache.uuid_to_name[col._uuid] for col in left)
+    right_names = set(right._cache.uuid_to_name[col._uuid] for col in right)
+
     if user_suffix is not None:
         for name in right._cache.name_to_uuid.keys():
             if name + suffix in left_names:
@@ -1061,9 +1063,9 @@ def join(
                     "hint: Specify a different suffix to prevent name collisions or "
                     "none at all for automatic name collision resolution."
                 )
-    elif (set(right._cache.name_to_uuid.keys()) - ignore_right) & left_names:
+    elif (right_names - ignore_right) & left_names:
         cnt = 0
-        for name in set(right._cache.name_to_uuid.keys()) - ignore_right:
+        for name in right_names - ignore_right:
             suffixed = name + suffix + (f"_{cnt}" if cnt > 0 else "")
             while suffixed in left_names:
                 cnt += 1

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -523,7 +523,7 @@ def mutate(table: Table, **kwargs: ColExpr) -> Pipeable:
     if len(kwargs) == 0:
         return table
 
-    names, values = map(list, zip(*kwargs.items(), strict=True))
+    names, values = kwargs.keys(), kwargs.values()
     uuids = [uuid.uuid1() for _ in names]
     new = copy.copy(table)
 
@@ -816,7 +816,7 @@ def summarize(table: Table, **kwargs: ColExpr) -> Pipeable:
     │ false ┆ 9.0      ┆ 5.077 │
     └───────┴──────────┴───────┘
     """
-    names, values = map(list, zip(*kwargs.items(), strict=True))
+    names, values = kwargs.keys(), kwargs.values()
     uuids = [uuid.uuid1() for _ in names]
     new = copy.copy(table)
 
@@ -828,6 +828,12 @@ def summarize(table: Table, **kwargs: ColExpr) -> Pipeable:
     )
 
     partition_by_uuids = {col._uuid for col in table._cache.partition_by}
+
+    if len(kwargs) == 0 and len(partition_by_uuids) == 0:
+        raise ValueError(
+            "summarize without preceding group_by needs at least one column to "
+            "summarize"
+        )
 
     def check_summarize_col_expr(expr: ColExpr, agg_fn_above: bool):
         if (

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -969,8 +969,7 @@ def join(
     :param coalesce:
         If `on` is a list of strings and `coalesce=True`, the join columns are merged.
         If there are no column name collisions apart from the join columns, no suffix is
-        appended to columns of the right table. Can currently only be used with inner
-        and left join.
+        appended to columns of the right table.
 
 
     Note
@@ -1022,9 +1021,6 @@ def join(
         ["1:1", "1:m", "m:1", "m:m"], "join", "validate", validate
     )
     errors.check_arg_type(bool, "join", "coalesce", coalesce)
-
-    if how == "full" and coalesce:
-        raise ValueError("cannot use `coalesce=True` with full join")
 
     if isinstance(on, str):
         on = [on]

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -654,6 +654,8 @@ def arrange(table: Table, *order_by: ColExpr) -> Pipeable:
     if len(order_by) == 0:
         return table
 
+    order_by = [ColName(col) if isinstance(col, str) else col for col in order_by]
+
     new = copy.copy(table)
     new._ast = Arrange(
         table._ast,
@@ -964,6 +966,12 @@ def join(
         name collisions, additionally an integer is appended to the column names of the
         right table.
 
+    :param coalesce:
+        If `on` is a list of strings and `coalesce=True`, the join columns are merged.
+        If there are no column name collisions apart from the join columns, no suffix is
+        appended to columns of the right table. Can currently only be used with inner
+        and left join.
+
 
     Note
     ----
@@ -1014,6 +1022,9 @@ def join(
         ["1:1", "1:m", "m:1", "m:m"], "join", "validate", validate
     )
     errors.check_arg_type(bool, "join", "coalesce", coalesce)
+
+    if how == "full" and coalesce:
+        raise ValueError("cannot use `coalesce=True` with full join")
 
     if isinstance(on, str):
         on = [on]

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -524,7 +524,7 @@ def mutate(table: Table, **kwargs: ColExpr) -> Pipeable:
     if len(kwargs) == 0:
         return table
 
-    names, values = kwargs.keys(), kwargs.values()
+    names, values = list(kwargs.keys()), list(kwargs.values())
     uuids = [uuid.uuid1() for _ in names]
     new = copy.copy(table)
 
@@ -817,7 +817,7 @@ def summarize(table: Table, **kwargs: ColExpr) -> Pipeable:
     │ false ┆ 9.0      ┆ 5.077 │
     └───────┴──────────┴───────┘
     """
-    names, values = kwargs.keys(), kwargs.values()
+    names, values = list(kwargs.keys()), list(kwargs.values())
     uuids = [uuid.uuid1() for _ in names]
     new = copy.copy(table)
 

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -837,6 +837,7 @@ def summarize(table: Table, **kwargs: ColExpr) -> Pipeable:
         )
 
     def check_summarize_col_expr(expr: ColExpr, agg_fn_above: bool):
+        # TODO: does not catch everything (test_alias_window)
         if (
             isinstance(expr, Col)
             and expr._uuid not in partition_by_uuids
@@ -1100,6 +1101,8 @@ def join(
 
     new._cache = copy.copy(left._cache)
     new._cache.update(new._ast, rcache=right._cache)
+    # TODO: make sure that error messages (e.g. for non-existent columns) use the
+    # correct table name.
     new._ast.on = preprocess_arg(new._ast.on, new)
     ignore_uuids = set(right[col]._uuid for col in ignore_right)
     new._cache.select = left._cache.select + [

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -36,6 +36,7 @@ from pydiverse.transform._internal.tree.types import (
     Duration,
     Float,
     Int,
+    List,
     String,
     python_type_to_pdt,
 )
@@ -1491,6 +1492,7 @@ class ColExpr(Generic[T]):
     str: StrNamespace
     dt: DtNamespace
     dur: DurNamespace
+    list: ListNamespace
 
 
 @dataclasses.dataclass(slots=True)
@@ -2000,6 +2002,29 @@ class DurNamespace(FnNamespace):
         """"""
 
         return ColFn(ops.dur_seconds, self.arg)
+
+
+@register_accessor("list")
+@dataclasses.dataclass(slots=True)
+class ListNamespace(FnNamespace):
+    def agg(
+        self: ColExpr,
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+        filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
+    ) -> ColExpr[List]:
+        """
+        Collect the elements of each group in a list.
+        """
+
+        return ColFn(
+            ops.list_agg,
+            self.arg,
+            partition_by=partition_by,
+            arrange=arrange,
+            filter=filter,
+        )
 
 
 # --- generated code ends here, do not delete this comment ---

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -307,6 +307,16 @@ class ColExpr(Generic[T]):
         self: ColExpr[Duration], rhs: ColExpr[Duration]
     ) -> ColExpr[Duration]: ...
 
+    @overload
+    def __add__(
+        self: ColExpr[Datetime], rhs: ColExpr[Duration]
+    ) -> ColExpr[Datetime]: ...
+
+    @overload
+    def __add__(
+        self: ColExpr[Duration], rhs: ColExpr[Datetime]
+    ) -> ColExpr[Datetime]: ...
+
     def __add__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Addition +"""
 
@@ -328,6 +338,16 @@ class ColExpr(Generic[T]):
     def __radd__(
         self: ColExpr[Duration], rhs: ColExpr[Duration]
     ) -> ColExpr[Duration]: ...
+
+    @overload
+    def __radd__(
+        self: ColExpr[Datetime], rhs: ColExpr[Duration]
+    ) -> ColExpr[Datetime]: ...
+
+    @overload
+    def __radd__(
+        self: ColExpr[Duration], rhs: ColExpr[Datetime]
+    ) -> ColExpr[Datetime]: ...
 
     def __radd__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Addition +"""

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -1269,6 +1269,42 @@ class ColExpr(Generic[T]):
         return ColFn(ops.pow, rhs, self)
 
     @overload
+    def prefix_sum(
+        self: ColExpr[Int],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+    ) -> ColExpr[Int]: ...
+
+    @overload
+    def prefix_sum(
+        self: ColExpr[Float],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+    ) -> ColExpr[Float]: ...
+
+    @overload
+    def prefix_sum(
+        self: ColExpr[Decimal],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+    ) -> ColExpr[Decimal]: ...
+
+    def prefix_sum(
+        self: ColExpr,
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+    ) -> ColExpr:
+        """
+        The sum of all preceding elements and the current element.
+        """
+
+        return ColFn(ops.prefix_sum, self, partition_by=partition_by, arrange=arrange)
+
+    @overload
     def round(self: ColExpr[Int], decimals: int = 0) -> ColExpr[Int]: ...
 
     @overload

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -1351,12 +1351,6 @@ class ColExpr(Generic[T]):
     @overload
     def __sub__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Duration]: ...
 
-    @overload
-    def __sub__(self: ColExpr[Datetime], rhs: ColExpr[Date]) -> ColExpr[Duration]: ...
-
-    @overload
-    def __sub__(self: ColExpr[Date], rhs: ColExpr[Datetime]) -> ColExpr[Duration]: ...
-
     def __sub__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Subtraction -"""
 
@@ -1378,12 +1372,6 @@ class ColExpr(Generic[T]):
 
     @overload
     def __rsub__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Duration]: ...
-
-    @overload
-    def __rsub__(self: ColExpr[Datetime], rhs: ColExpr[Date]) -> ColExpr[Duration]: ...
-
-    @overload
-    def __rsub__(self: ColExpr[Date], rhs: ColExpr[Datetime]) -> ColExpr[Duration]: ...
 
     def __rsub__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Subtraction -"""
@@ -2382,6 +2370,7 @@ class Cast(ColExpr):
                     for ft, it in itertools.product(FLOAT_SUBTYPES, INT_SUBTYPES)
                 ),
                 (Datetime(), Date()),
+                (Date(), Datetime()),
                 *(
                     (t, String())
                     for t in (

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -1553,6 +1553,29 @@ class StrNamespace(FnNamespace):
 
         return ColFn(ops.str_ends_with, self.arg, suffix)
 
+    def join(
+        self: ColExpr[String],
+        delimiter: str = "",
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
+        arrange: ColExpr | Iterable[ColExpr] | None = None,
+    ) -> ColExpr[String]:
+        """
+        Concatenates all strings in a group to a single string.
+
+        :param delimiter:
+            The string to insert between the elements."""
+
+        return ColFn(
+            ops.str_join,
+            self.arg,
+            delimiter,
+            partition_by=partition_by,
+            filter=filter,
+            arrange=arrange,
+        )
+
     def len(self: ColExpr[String]) -> ColExpr[Int]:
         """
         Computes the length of the string.

--- a/src/pydiverse/transform/_internal/tree/types.py
+++ b/src/pydiverse/transform/_internal/tree/types.py
@@ -275,6 +275,7 @@ IMPLICIT_CONVS: dict[Dtype, dict[Dtype, tuple[int, int]]] = {
         **{t: (1, 0) for t in ALL_TYPES if t != NullType()},
     },
     Duration(): {Duration(): (0, 0)},
+    List(): {List(): (0, 0)},
 }
 
 # compute transitive closure of cost graph

--- a/src/pydiverse/transform/_internal/tree/types.py
+++ b/src/pydiverse/transform/_internal/tree/types.py
@@ -112,6 +112,9 @@ class Date(Dtype): ...
 class Duration(Dtype): ...
 
 
+class List(Dtype): ...
+
+
 class NullType(Dtype): ...
 
 
@@ -159,6 +162,8 @@ def python_type_to_pdt(t: type) -> Dtype:
         return Date()
     elif t is datetime.timedelta:
         return Duration()
+    elif t is list:
+        return List()
     elif t is type(None):
         return NullType()
 
@@ -183,6 +188,8 @@ def pdt_type_to_python(t: Dtype) -> type:
         return datetime.date
     elif t <= Duration():
         return datetime.timedelta
+    elif t <= List():
+        return list
     elif t <= NullType():
         return type(None)
 
@@ -235,6 +242,7 @@ ALL_TYPES = (
     Bool(),
     NullType(),
     Duration(),
+    List(),
 )
 
 

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -180,6 +180,7 @@ class Join(Verb):
     how: Literal["inner", "left", "full"]
     validate: Literal["1:1", "1:m", "m:1", "m:m"]
     suffix: str
+    coalesce: bool
 
     def _clone(self) -> tuple[Join, dict[AstNode, AstNode], dict[UUID, UUID]]:
         child, nd_map, uuid_map = self.child._clone()

--- a/src/pydiverse/transform/common.py
+++ b/src/pydiverse/transform/common.py
@@ -4,6 +4,7 @@ from ._internal.backend.targets import DuckDb, Pandas, Polars, SqlAlchemy
 from ._internal.pipe.pipeable import verb
 from ._internal.pipe.verbs import (
     arrange,
+    cross_join,
     drop,
     full_join,
     group_by,
@@ -25,11 +26,12 @@ __all__ = __base + [
     "arrange",
     "drop",
     "group_by",
-    "inner_join",
     "join",
+    "inner_join",
     "left_join",
-    "mutate",
     "full_join",
+    "cross_join",
+    "mutate",
     "rename",
     "select",
     "slice_head",

--- a/src/pydiverse/transform/types.py
+++ b/src/pydiverse/transform/types.py
@@ -14,6 +14,7 @@ from ._internal.tree.types import (
     Int16,
     Int32,
     Int64,
+    List,
     String,
     Uint8,
     Uint16,
@@ -41,4 +42,5 @@ __all__ = [
     "Uint32",
     "Uint64",
     "Dtype",
+    "List",
 ]

--- a/tests/test_backend_equivalence/test_alias.py
+++ b/tests/test_backend_equivalence/test_alias.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from pydiverse.transform.extended import *
+from tests.util import assert_result_equal
+
+
+def test_alias(df3):
+    assert_result_equal(df3, lambda t: t >> alias())
+
+
+def test_alias_named(df3):
+    def run(post_op):
+        assert_result_equal(df3, lambda t: t >> alias("a") >> post_op)
+
+    for post_op in [
+        mutate(),
+        mutate(y=C.col1),
+        mutate(y=C.col1.count()),
+        mutate(y=C.col1.count(partition_by=C.col2)),
+        summarize(y=C.col1.count()),
+    ]:
+        run(post_op)
+
+
+def test_alias_mutate(df3):
+    def run(post_op):
+        assert_result_equal(
+            df3, lambda t: t >> mutate(x=t.col1) >> alias("a") >> post_op
+        )
+
+    for post_op in [
+        mutate(),
+        mutate(y=C.col1),
+        mutate(y=C.col1.count()),
+        mutate(y=C.col1.count(partition_by=C.col2)),
+        summarize(y=C.col1.count()),
+    ]:
+        run(post_op)
+
+
+@pytest.mark.xfail  # TODO: fix problem with errors
+def test_alias_window(df3):
+    def run(post_op):
+        assert_result_equal(
+            df3,
+            lambda t: t
+            >> mutate(x=t.col1.count(partition_by=t.col2))
+            >> alias("a")
+            >> post_op,
+        )
+
+    for post_op in [
+        mutate(),
+        mutate(y=C.col1),
+        mutate(y=C.col1.count()),
+        mutate(y=C.col1.count(partition_by=C.col2)),
+        summarize(y=C.col1.count() + C.x.sum()),
+        summarize(y=C.col1.count() + C.x),
+    ]:
+        run(post_op)
+
+
+@pytest.mark.xfail  # TODO: fix problem with errors
+def test_alias_summarize(df3):
+    def run(post_op):
+        assert_result_equal(
+            df3,
+            lambda t: t
+            >> group_by(t.col1, t.col2)
+            >> summarize(x=t.col1.count())
+            >> alias("a")
+            >> post_op,
+        )
+
+    for post_op in [
+        mutate(),
+        mutate(y=C.col1),
+        mutate(y=C.col1.count()),
+        mutate(y=C.col1.count(partition_by=C.col2)),
+        summarize(y=C.col1.count()),
+        mutate(y=C.x < row_number()),
+    ]:
+        run(post_op)

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -36,6 +36,11 @@ def test_join(df1, df2, how):
 
     assert_result_equal(
         (df1, df2),
+        lambda t, u: t >> join(u, on="col1", how=how, coalesce=True),
+    )
+
+    assert_result_equal(
+        (df1, df2),
         lambda t, u: t
         >> join(u, on=["col1", t.col1.cast(pdt.Float64()) >= u.col3], how=how),
     )

--- a/tests/test_backend_equivalence/test_mutate.py
+++ b/tests/test_backend_equivalence/test_mutate.py
@@ -58,3 +58,10 @@ def test_mutate_bool_expr(df4):
         >> mutate(x=t.col1 <= t.col2, y=(t.col3 * 4) >= C.col4)
         >> mutate(xAndY=C.x & C.y),
     )
+
+
+def test_hidden_cols(df1):
+    assert_result_equal(
+        df1,
+        lambda t: t >> select() >> mutate(col1=4) >> mutate(col1=C.col1 + t.col1),
+    )

--- a/tests/test_backend_equivalence/test_mutate.py
+++ b/tests/test_backend_equivalence/test_mutate.py
@@ -39,6 +39,10 @@ def test_literals(df1):
     assert_result_equal(df1, lambda t: t >> mutate(u=pdt.lit(None)))
 
 
+def test_empty(df1):
+    assert_result_equal(df1, lambda t: t >> mutate())
+
+
 def test_none(df4):
     assert_result_equal(df4, lambda t: t >> mutate(x=None))
     assert_result_equal(

--- a/tests/test_backend_equivalence/test_ops/test_ops_datetime.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_datetime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pydiverse.transform as pdt
 from pydiverse.transform.extended import *
 from tests.util import assert_result_equal
 
@@ -153,6 +154,17 @@ def test_day_of_year(df_datetime):
         >> mutate(
             x=C.col1.dt.day_of_year(),
             y=C.col2.dt.day_of_year(),
+        ),
+    )
+
+
+def test_cast(df_datetime):
+    assert_result_equal(
+        df_datetime,
+        lambda t: t
+        >> mutate(
+            x=t.cdate.cast(pdt.Datetime()),
+            y=t.col1.cast(pdt.Date()),
         ),
     )
 

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -154,3 +154,9 @@ def test_slice(df_strings):
             w=t.col1.str.slice(2, t.col1.str.len()),
         ),
     )
+
+
+def test_str_join(df_strings):
+    assert_result_equal(
+        df_strings, lambda t: t >> group_by(t.e) >> summarize(con=t.c.str.join(", "))
+    )

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -12,12 +12,16 @@ def test_ungrouped(df3):
         lambda t: t >> summarize(mean3=t.col3.mean(), mean4=t.col4.mean()),
     )
 
+    assert_result_equal(df3, lambda t: t >> summarize())
+
 
 def test_simple_grouped(df3):
     assert_result_equal(
         df3,
         lambda t: t >> group_by(t.col1) >> summarize(mean3=t.col3.mean()),
     )
+
+    assert_result_equal(df3, lambda t: t >> group_by(t.col1) >> summarize())
 
 
 def test_multi_grouped(df3):

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -12,7 +12,9 @@ def test_ungrouped(df3):
         lambda t: t >> summarize(mean3=t.col3.mean(), mean4=t.col4.mean()),
     )
 
-    assert_result_equal(df3, lambda t: t >> summarize())
+
+def test_empty_ungrouped_fail(df3):
+    assert_result_equal(df3, lambda t: t >> summarize(), exception=ValueError)
 
 
 def test_simple_grouped(df3):

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -54,6 +54,12 @@ def test_chained_summarized(df3):
     )
 
 
+def test_summarize_name_drop(df3):
+    assert_result_equal(
+        df3, lambda t: t >> summarize(x=t.col1.count()) >> mutate(col1=1, col2=2)
+    )
+
+
 def test_nested(df3):
     assert_result_equal(
         df3,

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -175,7 +175,7 @@ class TestPolarsLazyImpl:
             tbl_left
             >> join(tbl_right, tbl_left.a == tbl_right.b, "left")
             >> select(tbl_left.a, tbl_right.b),
-            pl.DataFrame({"a": [1, 2, 2, 3, 4], "b_df_right": [1, 2, 2, None, None]}),
+            pl.DataFrame({"a": [1, 2, 2, 3, 4], "b": [1, 2, 2, None, None]}),
             check_row_order=False,
         )
 

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -140,6 +140,11 @@ class TestPolarsLazyImpl:
 
     def test_mutate(self, tbl1):
         assert_equal(
+            tbl1 >> select() >> mutate(col1=4) >> mutate(col1=C.col1 + tbl1.col1),
+            df1.with_columns(col1=pl.col("col1") + 4).select("col1"),
+        )
+
+        assert_equal(
             tbl1 >> mutate(col1times2=tbl1.col1 * 2),
             pl.DataFrame(
                 {
@@ -487,7 +492,7 @@ class TestPolarsLazyImpl:
             tbl1
             >> select()
             >> mutate(a=tbl1.col1)
-            >> join(tbl2, tbl1.col1 == tbl2.col1, "left"),
+            >> join(tbl2, tbl1.col1 == tbl2.col1, "left", suffix="_df2"),
         )
 
         # Filter
@@ -541,7 +546,9 @@ class TestPolarsLazyImpl:
             >> mutate(
                 u=(tbl_dt.dt1 - tbl_dt.dt2),
                 v=tbl_dt.d1 - tbl_dt.d1,
-                w=(tbl_dt.d1 - tbl_dt.dt2) + tbl_dt.dur1 + dt.timedelta(days=1),
+                w=(tbl_dt.d1.cast(pdt.Datetime) - tbl_dt.dt2)
+                + tbl_dt.dur1
+                + dt.timedelta(days=1),
             ),
             df_dt.with_columns(
                 (pl.col("dt1") - pl.col("dt2")).alias("u"),

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -617,6 +617,12 @@ class TestPolarsLazyImpl:
             s.with_columns(b=[[5], [0.3, 3.66], []]),
         )
 
+    def test_prefix_sum(self, tbl1):
+        assert_equal(
+            tbl1 >> mutate(p=tbl1.col1.prefix_sum()),
+            df1.with_columns(p=pl.col("col1").cum_sum()),
+        )
+
 
 class TestPrintAndRepr:
     def test_table_str(self, tbl1):

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -604,7 +604,7 @@ class TestPolarsLazyImpl:
             (e >> mutate(j=e.col2 + tbl1.col1)).j.export(Polars()),
         )
 
-    def test_list(self, tbl1):
+    def test_list(self, tbl1, tbl3):
         df = tbl1 >> export(Polars())
         df = df.with_columns(l=[[1, 2], [], [4, 5, 5], [2, 3]])
         assert_equal(pdt.Table(df), df)
@@ -615,6 +615,16 @@ class TestPolarsLazyImpl:
         assert_equal(
             t >> mutate(b=[[5], [0.3, 3.66], []]),
             s.with_columns(b=[[5], [0.3, 3.66], []]),
+        )
+
+        assert_equal(
+            tbl3
+            >> group_by(tbl3.col1)
+            >> summarize(x=tbl3.col3.list.agg(arrange="col4"))
+            >> arrange(tbl3.col1),
+            df3.group_by(pl.col("col1"))
+            .agg(x=pl.col("col3").sort_by("col4"))
+            .sort("col1"),
         )
 
     def test_prefix_sum(self, tbl1):

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -597,6 +597,19 @@ class TestPolarsLazyImpl:
             (e >> mutate(j=e.col2 + tbl1.col1)).j.export(Polars()),
         )
 
+    def test_list(self, tbl1):
+        df = tbl1 >> export(Polars())
+        df = df.with_columns(l=[[1, 2], [], [4, 5, 5], [2, 3]])
+        assert_equal(pdt.Table(df), df)
+        d = {"a": [["b", "aa"], ["a"], []]}
+        t = pdt.Table(d)
+        s = pl.DataFrame(d)
+        assert_equal(t, s)
+        assert_equal(
+            t >> mutate(b=[[5], [0.3, 3.66], []]),
+            s.with_columns(b=[[5], [0.3, 3.66], []]),
+        )
+
 
 class TestPrintAndRepr:
     def test_table_str(self, tbl1):

--- a/tests/test_sql_table.py
+++ b/tests/test_sql_table.py
@@ -334,7 +334,7 @@ class TestSqlTable:
             tbl1
             >> select()
             >> mutate(a=tbl1.col1)
-            >> join(tbl2, tbl1.col1 == tbl2.col1, "left"),
+            >> join(tbl2, tbl1.col1 == tbl2.col1, "left", suffix="_df2"),
         )
 
         # Filter


### PR DESCRIPTION
- In polars, column renaming before a join did not work correctly
- The table cache can now deal with multiple UUIDs mapping to the same name. This is necessary for the "coalesce" option in "join"
- List type
- string aggregation
- cross join