### PR TITLE
Use pydiverse common, add column operations and handle subqueries eagerly

### DIFF
--- a/fuzz.py
+++ b/fuzz.py
@@ -16,7 +16,7 @@ from pydiverse.transform._internal.ops.op import Ftype, Operator
 from pydiverse.transform._internal.ops.ops.markers import Marker
 from pydiverse.transform._internal.ops.signature import Signature
 from pydiverse.transform._internal.tree.col_expr import ColFn
-from pydiverse.transform._internal.tree.types import Tvar
+from pydiverse.transform._internal.tree.types import Tyvar
 from pydiverse.transform.common import *  # noqa: F403
 from tests.util.backend import BACKEND_TABLES
 
@@ -65,20 +65,22 @@ for op in ops.__dict__.values():
     ):
         continue
     for sig in op.signatures:
-        if not all(t in (*ALL_TYPES, Tvar("T")) for t in (*sig.types, sig.return_type)):
+        if not all(
+            t in (*ALL_TYPES, Tyvar("T")) for t in (*sig.types, sig.return_type)
+        ):
             continue
 
-        if isinstance(sig.return_type, Tvar) or any(
-            isinstance(param, Tvar) for param in sig.types
+        if isinstance(sig.return_type, Tyvar) or any(
+            isinstance(param, Tyvar) for param in sig.types
         ):
             for ty in ALL_TYPES:
-                rtype = ty if isinstance(sig.return_type, Tvar) else sig.return_type
+                rtype = ty if isinstance(sig.return_type, Tyvar) else sig.return_type
                 ops_with_return_type[rtype].append(
                     (
                         op,
                         Signature(
                             *(
-                                ty if isinstance(param, Tvar) else param
+                                ty if isinstance(param, Tyvar) else param
                                 for param in sig.types
                             ),
                             return_type=rtype,

--- a/generate_col_ops.py
+++ b/generate_col_ops.py
@@ -4,14 +4,12 @@ import os
 from collections.abc import Iterable
 from types import NoneType
 
+from pydiverse.common import Dtype
 from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import (
-    Dtype,
-    Tvar,
-    pdt_type_to_python,
-)
+from pydiverse.transform._internal.tree import types
+from pydiverse.transform._internal.tree.types import Tyvar
 
 COL_EXPR_PATH = "./src/pydiverse/transform/_internal/tree/col_expr.py"
 FNS_PATH = "./src/pydiverse/transform/_internal/pipe/functions.py"
@@ -39,10 +37,12 @@ def add_vararg_star(formatted_args: str) -> str:
 
 
 def type_annotation(dtype: Dtype, specialize_generic: bool) -> str:
-    if (not specialize_generic and not dtype.const) or isinstance(dtype, Tvar):
+    if (not specialize_generic and not types.is_const(dtype)) or isinstance(
+        types.without_const(dtype), Tyvar
+    ):
         return "ColExpr"
-    if dtype.const:
-        python_type = pdt_type_to_python(dtype)
+    if types.is_const(dtype):
+        python_type = types.to_python(dtype)
         return python_type.__name__ if python_type is not NoneType else "None"
     return f"ColExpr[{dtype.__class__.__name__}]"
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -117,6 +117,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyodbc-5.2.0-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -255,6 +256,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py312h5157fe3_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyodbc-5.2.0-py312hae40c12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -392,6 +394,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py312hc40f475_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyodbc-5.2.0-py312hf02c72a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -514,6 +517,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyodbc-5.2.0-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -667,6 +671,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py313h78bf25f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py313he5f92c8_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.1-ha99a958_102_cp313.conda
@@ -809,6 +814,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py313habf4b1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py313hc71e1e6_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.1-h2334245_102_cp313.conda
@@ -951,6 +957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py313h39782a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py313hf9431ad_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.1-h4f43103_102_cp313.conda
@@ -1080,6 +1087,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py313hfa70ccb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py313he812468_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.1-h071d269_102_cp313.conda
@@ -1238,6 +1246,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py310hff52083_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py310hac404ae_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyodbc-5.2.0-py310hf71b8c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -1375,6 +1384,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py310h2ec42d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py310h86202ae_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyodbc-5.2.0-py310h2e7bc63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -1511,6 +1521,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py310hb6292c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py310hc17921c_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyodbc-5.2.0-py310hdde5576_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -1632,6 +1643,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py310h5588dad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py310h399dd74_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyodbc-5.2.0-py310h9e98ed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -1786,6 +1798,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py311h4854187_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyodbc-5.2.0-py311hfdbb021_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -1924,6 +1937,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py311he02522f_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyodbc-5.2.0-py311ha701b48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2061,6 +2075,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py311ha1ab1f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py311he04fa90_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyodbc-5.2.0-py311h6885ffc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2183,6 +2198,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py311hdea38fa_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyodbc-5.2.0-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2337,6 +2353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyodbc-5.2.0-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2475,6 +2492,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py312h5157fe3_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyodbc-5.2.0-py312hae40c12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2612,6 +2630,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-18.1.0-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-18.1.0-py312hc40f475_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyodbc-5.2.0-py312hf02c72a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2734,6 +2753,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyodbc-5.2.0-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -2892,6 +2912,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-18.1.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyodbc-5.2.0-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -3031,6 +3052,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-18.1.0-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-18.1.0-py312h5157fe3_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyodbc-5.2.0-py312hae40c12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -3156,6 +3178,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-18.1.0-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyodbc-5.2.0-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_1.conda
@@ -3545,8 +3568,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
-  arch: x86_64
-  platform: linux
   license: None
   purls: []
   size: 2562
@@ -3560,8 +3581,6 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -3603,8 +3622,6 @@ packages:
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3620,8 +3637,6 @@ packages:
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3637,8 +3652,6 @@ packages:
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 92507
@@ -3655,8 +3668,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3670,8 +3681,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - libgcc >=13
   - openssl >=3.3.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3684,8 +3693,6 @@ packages:
   - __osx >=10.13
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - openssl >=3.3.1,<4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3698,8 +3705,6 @@ packages:
   - __osx >=11.0
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - openssl >=3.3.1,<4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 39925
@@ -3713,8 +3718,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3726,8 +3729,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3738,8 +3739,6 @@ packages:
   md5: 9f0bbd4a339c01ec81d7e19cbb9ad2ed
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3750,8 +3749,6 @@ packages:
   md5: 145e5b4c9702ed279d7d68aaf096f77d
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 221863
@@ -3763,8 +3760,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3777,8 +3772,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3790,8 +3783,6 @@ packages:
   depends:
   - __osx >=10.13
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3803,8 +3794,6 @@ packages:
   depends:
   - __osx >=11.0
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 18068
@@ -3817,8 +3806,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3834,8 +3821,6 @@ packages:
   - aws-checksums >=0.2.2,<0.2.3.0a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3850,8 +3835,6 @@ packages:
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-checksums >=0.2.2,<0.2.3.0a0
   - libcxx >=18
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3866,8 +3849,6 @@ packages:
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-checksums >=0.2.2,<0.2.3.0a0
   - libcxx >=18
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 47078
@@ -3882,8 +3863,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3899,8 +3878,6 @@ packages:
   - aws-c-compression >=0.3.0,<0.3.1.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3915,8 +3892,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - aws-c-compression >=0.3.0,<0.3.1.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3931,8 +3906,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - aws-c-compression >=0.3.0,<0.3.1.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 152983
@@ -3948,8 +3921,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3964,8 +3935,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - libgcc >=13
   - s2n >=1.5.10,<1.5.11.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3978,8 +3947,6 @@ packages:
   - __osx >=10.13
   - aws-c-cal >=0.8.1,<0.8.2.0a0
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3992,8 +3959,6 @@ packages:
   - __osx >=11.0
   - aws-c-cal >=0.8.1,<0.8.2.0a0
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 135729
@@ -4007,8 +3972,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4023,8 +3986,6 @@ packages:
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4038,8 +3999,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4053,8 +4012,6 @@ packages:
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 134371
@@ -4069,8 +4026,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4089,8 +4044,6 @@ packages:
   - aws-checksums >=0.2.2,<0.2.3.0a0
   - libgcc >=13
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4107,8 +4060,6 @@ packages:
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-checksums >=0.2.2,<0.2.3.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4125,8 +4076,6 @@ packages:
   - aws-c-http >=0.9.2,<0.9.3.0a0
   - aws-c-io >=0.15.3,<0.15.4.0a0
   - aws-checksums >=0.2.2,<0.2.3.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 97598
@@ -4144,8 +4093,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4158,8 +4105,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4171,8 +4116,6 @@ packages:
   depends:
   - __osx >=10.13
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4184,8 +4127,6 @@ packages:
   depends:
   - __osx >=11.0
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 49664
@@ -4198,8 +4139,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4212,8 +4151,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.10.6,<0.10.7.0a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4225,8 +4162,6 @@ packages:
   depends:
   - __osx >=10.13
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4238,8 +4173,6 @@ packages:
   depends:
   - __osx >=11.0
   - aws-c-common >=0.10.6,<0.10.7.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 70186
@@ -4252,8 +4185,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4275,8 +4206,6 @@ packages:
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4297,8 +4226,6 @@ packages:
   - aws-c-s3 >=0.7.7,<0.7.8.0a0
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   - libcxx >=18
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4319,8 +4246,6 @@ packages:
   - aws-c-s3 >=0.7.7,<0.7.8.0a0
   - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   - libcxx >=18
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 236249
@@ -4341,8 +4266,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4362,8 +4285,6 @@ packages:
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4382,8 +4303,6 @@ packages:
   - libcxx >=18
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4402,8 +4321,6 @@ packages:
   - libcxx >=18
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 2826534
@@ -4420,8 +4337,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -4436,8 +4351,6 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4451,8 +4364,6 @@ packages:
   - libcurl >=8.10.1,<9.0a0
   - libcxx >=17
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4466,8 +4377,6 @@ packages:
   - libcurl >=8.10.1,<9.0a0
   - libcxx >=17
   - openssl >=3.3.2,<4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 294299
@@ -4481,8 +4390,6 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4496,8 +4403,6 @@ packages:
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - libcxx >=17
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4511,8 +4416,6 @@ packages:
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - libcxx >=17
   - openssl >=3.3.2,<4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 166907
@@ -4526,8 +4429,6 @@ packages:
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4541,8 +4442,6 @@ packages:
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libcxx >=17
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4556,8 +4455,6 @@ packages:
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libcxx >=17
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 438636
@@ -4572,8 +4469,6 @@ packages:
   - libstdcxx >=13
   - libxml2 >=2.12.7,<3.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4588,8 +4483,6 @@ packages:
   - libcxx >=17
   - libxml2 >=2.12.7,<3.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4604,8 +4497,6 @@ packages:
   - libcxx >=17
   - libxml2 >=2.12.7,<3.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 121278
@@ -4620,8 +4511,6 @@ packages:
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4636,8 +4525,6 @@ packages:
   - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libcxx >=17
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4652,8 +4539,6 @@ packages:
   - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - libcxx >=17
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 196032
@@ -4708,8 +4593,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - libbrotlicommon 1.1.0 hb9d3cd8_2
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 350424
@@ -4724,8 +4607,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - libbrotlicommon 1.1.0 h00291cd_2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 363156
@@ -4741,8 +4622,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - libbrotlicommon 1.1.0 hd74edd7_2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 339067
@@ -4758,8 +4637,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - libbrotlicommon 1.1.0 h2466b09_2
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 322309
@@ -4770,8 +4647,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -4782,8 +4657,6 @@ packages:
   md5: 7ed4301d437b59045be7e051a0308211
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -4794,8 +4667,6 @@ packages:
   md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: bzip2-1.0.6
   license_family: BSD
   size: 122909
@@ -4807,8 +4678,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -4820,8 +4689,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -4832,8 +4699,6 @@ packages:
   md5: 133255af67aaf1e0c0468cc753fd800b
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -4844,8 +4709,6 @@ packages:
   md5: c1c999a38a4303b29d75c636eaa13cf9
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 179496
@@ -4857,8 +4720,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -4867,8 +4728,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.12.14-hbcca054_0.conda
   sha256: 1afd7274cbc9a334d6d0bc62fa760acc7afdaceb0b91a8df370ec01fd75dc7dd
   md5: 720523eb0d6a9b0f6120c16b2aa4e7de
-  arch: x86_64
-  platform: linux
   license: ISC
   purls: []
   size: 157088
@@ -4876,8 +4735,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.12.14-h8857fd0_0.conda
   sha256: ddaafdcd1b8ace6ffeea22b6824ca9db8a64cf0a2652a11d7554ece54935fa06
   md5: b7b887091c99ed2e74845e75e9128410
-  arch: x86_64
-  platform: osx
   license: ISC
   purls: []
   size: 156925
@@ -4885,16 +4742,12 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
   sha256: 256be633fd0882ccc1a7a32bc278547e1703f85082c0789a87a603ee3ab8fb82
   md5: 7cb381a6783d91902638e4ed1ebd478e
-  arch: arm64
-  platform: osx
   license: ISC
   size: 157091
   timestamp: 1734208344343
 - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.12.14-h56e8100_0.conda
   sha256: 424d82db36cd26234bc4772426170efd60e888c2aed0099a257a95e131683a5e
   md5: cb2eaeb88549ddb27af533eccf9a45c1
-  arch: x86_64
-  platform: win
   license: ISC
   purls: []
   size: 157422
@@ -4917,8 +4770,6 @@ packages:
   - pycparser
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 243532
@@ -4933,8 +4784,6 @@ packages:
   - pycparser
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 302115
@@ -4949,8 +4798,6 @@ packages:
   - pycparser
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -4967,8 +4814,6 @@ packages:
   - pycparser
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 295514
@@ -4982,8 +4827,6 @@ packages:
   - pycparser
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 229844
@@ -4997,8 +4840,6 @@ packages:
   - pycparser
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 288762
@@ -5012,8 +4853,6 @@ packages:
   - pycparser
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -5029,8 +4868,6 @@ packages:
   - pycparser
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 284540
@@ -5045,8 +4882,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 229224
@@ -5061,8 +4896,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 288211
@@ -5077,8 +4910,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 281206
@@ -5093,8 +4924,6 @@ packages:
   - python >=3.13.0rc1,<3.14.0a0
   - python >=3.13.0rc1,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 282115
@@ -5109,8 +4938,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 238887
@@ -5125,8 +4952,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 297627
@@ -5141,8 +4966,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -5159,8 +4982,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 291828
@@ -5215,8 +5036,6 @@ packages:
   - libgcc >=13
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 137580
@@ -5229,8 +5048,6 @@ packages:
   - cffi >=1.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 117012
@@ -5244,8 +5061,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 113823
@@ -5260,8 +5075,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 121616
@@ -5289,8 +5102,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   size: 1576410
@@ -5304,8 +5115,6 @@ packages:
   - libntlm
   - libstdcxx-ng >=12
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause-Attribution
   license_family: BSD
   purls: []
@@ -5319,8 +5128,6 @@ packages:
   - libcxx >=15.0.7
   - libntlm
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause-Attribution
   license_family: BSD
   purls: []
@@ -5334,8 +5141,6 @@ packages:
   - libcxx >=15.0.7
   - libntlm
   - openssl >=3.1.1,<4.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause-Attribution
   license_family: BSD
   size: 210957
@@ -5347,8 +5152,6 @@ packages:
   - expat >=2.4.2,<3.0a0
   - libgcc-ng >=9.4.0
   - libglib >=2.70.2,<3.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 618596
@@ -5435,8 +5238,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libexpat 2.6.4 h5888daf_0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 138145
@@ -5471,8 +5272,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5484,8 +5283,6 @@ packages:
   depends:
   - __osx >=10.13
   - libcxx >=17
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5497,8 +5294,6 @@ packages:
   depends:
   - __osx >=11.0
   - libcxx >=17
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 82090
@@ -5510,8 +5305,6 @@ packages:
   - gflags >=2.2.2,<2.3.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5524,8 +5317,6 @@ packages:
   - __osx >=10.13
   - gflags >=2.2.2,<2.3.0a0
   - libcxx >=16
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5538,8 +5329,6 @@ packages:
   - __osx >=11.0
   - gflags >=2.2.2,<2.3.0a0
   - libcxx >=16
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 112215
@@ -5553,8 +5342,6 @@ packages:
   - libstdcxx >=13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 214503
@@ -5568,8 +5355,6 @@ packages:
   - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 240284
@@ -5583,8 +5368,6 @@ packages:
   - libstdcxx >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -5600,8 +5383,6 @@ packages:
   - libstdcxx >=13
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 237978
@@ -5614,8 +5395,6 @@ packages:
   - libcxx >=18
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 208760
@@ -5628,8 +5407,6 @@ packages:
   - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 235475
@@ -5642,8 +5419,6 @@ packages:
   - libcxx >=18
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -5658,8 +5433,6 @@ packages:
   - libcxx >=18
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 232090
@@ -5673,8 +5446,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 209577
@@ -5688,8 +5459,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 236404
@@ -5703,8 +5472,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 232021
@@ -5718,8 +5485,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 233061
@@ -5733,8 +5498,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 198778
@@ -5748,8 +5511,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 225722
@@ -5763,8 +5524,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -5780,8 +5539,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 222656
@@ -5922,8 +5679,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - setuptools
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -5941,8 +5696,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -5959,8 +5712,6 @@ packages:
   - python_abi 3.12.* *_cp312
   - setuptools
   - sqlalchemy
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -5977,8 +5728,6 @@ packages:
   - python_abi 3.12.* *_cp312
   - setuptools
   - sqlalchemy
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -5997,8 +5746,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.40.33810
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -6012,8 +5759,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -6024,8 +5769,6 @@ packages:
   md5: d68d48a3060eb5abdc1cdc8e2a3a5966
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -6036,8 +5779,6 @@ packages:
   md5: 5eb22c1d7b3fc4abb50d92d621583137
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 11857802
@@ -6049,8 +5790,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -6124,8 +5863,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
   sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
   md5: 2d89243bfb53652c182a7c73182cce4f
-  arch: x86_64
-  platform: win
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   purls: []
@@ -6233,8 +5970,6 @@ packages:
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
   - libgcc-ng >=10.3.0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 117831
@@ -6249,8 +5984,6 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - openssl >=3.3.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -6265,8 +5998,6 @@ packages:
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - openssl >=3.3.1,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -6281,8 +6012,6 @@ packages:
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - openssl >=3.3.1,<4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 1155530
@@ -6295,8 +6024,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -6309,8 +6036,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.43
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -6326,8 +6051,6 @@ packages:
   constrains:
   - abseil-cpp =20240722.0
   - libabseil-static =20240722.0=cxx17*
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -6342,8 +6065,6 @@ packages:
   constrains:
   - libabseil-static =20240722.0=cxx17*
   - abseil-cpp =20240722.0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -6358,8 +6079,6 @@ packages:
   constrains:
   - abseil-cpp =20240722.0
   - libabseil-static =20240722.0=cxx17*
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1173485
@@ -6374,8 +6093,6 @@ packages:
   constrains:
   - abseil-cpp =20240722.0
   - libabseil-static =20240722.0=cxx17*
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -6416,8 +6133,6 @@ packages:
   - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   purls: []
   size: 8770256
@@ -6455,8 +6170,6 @@ packages:
   - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   purls: []
   size: 6144451
@@ -6494,8 +6207,6 @@ packages:
   - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   size: 5506699
   timestamp: 1735682962976
@@ -6530,8 +6241,6 @@ packages:
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   purls: []
   size: 5303299
@@ -6545,8 +6254,6 @@ packages:
   - libarrow 18.1.0 hd595efa_7_cpu
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   purls: []
   size: 612463
@@ -6559,8 +6266,6 @@ packages:
   - __osx >=10.13
   - libarrow 18.1.0 h731e907_7_cpu
   - libcxx >=18
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   purls: []
   size: 523592
@@ -6573,8 +6278,6 @@ packages:
   - __osx >=11.0
   - libarrow 18.1.0 h0ad35bc_7_cpu
   - libcxx >=18
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   size: 485185
   timestamp: 1735683071232
@@ -6587,8 +6290,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   purls: []
   size: 447461
@@ -6604,8 +6305,6 @@ packages:
   - libgcc >=13
   - libparquet 18.1.0 h081d1f1_7_cpu
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   purls: []
   size: 587497
@@ -6620,8 +6319,6 @@ packages:
   - libarrow-acero 18.1.0 ha6338a2_7_cpu
   - libcxx >=18
   - libparquet 18.1.0 h3e22b07_7_cpu
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   purls: []
   size: 515138
@@ -6636,8 +6333,6 @@ packages:
   - libarrow-acero 18.1.0 hf07054f_7_cpu
   - libcxx >=18
   - libparquet 18.1.0 h636d7b7_7_cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   size: 491237
   timestamp: 1735684688308
@@ -6652,8 +6347,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   purls: []
   size: 435269
@@ -6672,8 +6365,6 @@ packages:
   - libgcc >=13
   - libprotobuf >=5.28.3,<5.28.4.0a0
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   purls: []
   size: 521861
@@ -6691,8 +6382,6 @@ packages:
   - libarrow-dataset 18.1.0 ha6338a2_7_cpu
   - libcxx >=18
   - libprotobuf >=5.28.3,<5.28.4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   purls: []
   size: 466013
@@ -6710,8 +6399,6 @@ packages:
   - libarrow-dataset 18.1.0 hf07054f_7_cpu
   - libcxx >=18
   - libprotobuf >=5.28.3,<5.28.4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   size: 452385
   timestamp: 1735684993831
@@ -6729,8 +6416,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   purls: []
   size: 365444
@@ -6747,8 +6432,6 @@ packages:
   - liblapack 3.9.0 26_linux64_openblas
   - liblapacke 3.9.0 26_linux64_openblas
   - blas * openblas
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -6766,8 +6449,6 @@ packages:
   - liblapack 3.9.0 26_osx64_openblas
   - blas * openblas
   - liblapacke 3.9.0 26_osx64_openblas
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -6785,8 +6466,6 @@ packages:
   - liblapacke 3.9.0 26_osxarm64_openblas
   - libcblas 3.9.0 26_osxarm64_openblas
   - blas * openblas
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16714
@@ -6802,8 +6481,6 @@ packages:
   - liblapack 3.9.0 26_win64_mkl
   - blas * mkl
   - libcblas 3.9.0 26_win64_mkl
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -6815,8 +6492,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -6827,8 +6502,6 @@ packages:
   md5: 58f2c4bdd56c46cc7451596e4ae68e0b
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -6839,8 +6512,6 @@ packages:
   md5: d0bf1dff146b799b319ea0434b93f779
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 68426
@@ -6852,8 +6523,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -6866,8 +6535,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libbrotlicommon 1.1.0 hb9d3cd8_2
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -6879,8 +6546,6 @@ packages:
   depends:
   - __osx >=10.13
   - libbrotlicommon 1.1.0 h00291cd_2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -6892,8 +6557,6 @@ packages:
   depends:
   - __osx >=11.0
   - libbrotlicommon 1.1.0 hd74edd7_2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 28378
@@ -6906,8 +6569,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -6920,8 +6581,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libbrotlicommon 1.1.0 hb9d3cd8_2
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -6933,8 +6592,6 @@ packages:
   depends:
   - __osx >=10.13
   - libbrotlicommon 1.1.0 h00291cd_2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -6946,8 +6603,6 @@ packages:
   depends:
   - __osx >=11.0
   - libbrotlicommon 1.1.0 hd74edd7_2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 279644
@@ -6960,8 +6615,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -6977,8 +6630,6 @@ packages:
   - liblapack 3.9.0 26_linux64_openblas
   - liblapacke 3.9.0 26_linux64_openblas
   - blas * openblas
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -6994,8 +6645,6 @@ packages:
   - liblapack 3.9.0 26_osx64_openblas
   - blas * openblas
   - liblapacke 3.9.0 26_osx64_openblas
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7011,8 +6660,6 @@ packages:
   - liblapack 3.9.0 26_osxarm64_openblas
   - liblapacke 3.9.0 26_osxarm64_openblas
   - blas * openblas
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16628
@@ -7027,8 +6674,6 @@ packages:
   - liblapacke 3.9.0 26_win64_mkl
   - liblapack 3.9.0 26_win64_mkl
   - blas * mkl
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7040,8 +6685,6 @@ packages:
   depends:
   - libgcc-ng >=9.4.0
   - libstdcxx-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7052,8 +6695,6 @@ packages:
   md5: 23d6d5a69918a438355d7cbc4c3d54c9
   depends:
   - libcxx >=11.1.0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7064,8 +6705,6 @@ packages:
   md5: 32bd82a6a625ea6ce090a81c3d34edeb
   depends:
   - libcxx >=11.1.0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 18765
@@ -7076,8 +6715,6 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7095,8 +6732,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: linux
   license: curl
   license_family: MIT
   purls: []
@@ -7113,8 +6748,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: osx
   license: curl
   license_family: MIT
   purls: []
@@ -7131,8 +6764,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: arm64
-  platform: osx
   license: curl
   license_family: MIT
   size: 385098
@@ -7147,8 +6778,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: curl
   license_family: MIT
   purls: []
@@ -7159,8 +6788,6 @@ packages:
   md5: 1bad6c181a0799298aad42fc5a7e98b7
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
@@ -7171,8 +6798,6 @@ packages:
   md5: ce5252d8db110cdb4ae4173d0a63c7c5
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 520992
@@ -7183,8 +6808,6 @@ packages:
   depends:
   - libgcc-ng >=7.5.0
   - ncurses >=6.2,<7.0.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -7195,8 +6818,6 @@ packages:
   md5: 6016a8a1d0e63cac3de2c352cd40208b
   depends:
   - ncurses >=6.2,<7.0.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -7207,8 +6828,6 @@ packages:
   md5: 30e4362988a2623e9eb34337b83e01f9
   depends:
   - ncurses >=6.2,<7.0.0a0
-  arch: arm64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 96607
@@ -7218,8 +6837,6 @@ packages:
   md5: 172bf1cd1ff8629f2b1179945ed45055
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -7228,8 +6845,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
   sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
   md5: 899db79329439820b7e8f8de41bca902
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -7238,8 +6853,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
   sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
   md5: 36d33e440c31857372a72137f78bacf5
-  arch: arm64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 107458
@@ -7250,8 +6863,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7262,8 +6873,6 @@ packages:
   md5: e38e467e577bd193a7d5de7c2c540b04
   depends:
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7274,8 +6883,6 @@ packages:
   md5: 1a109764bff3bdc7bdd84088347d71dc
   depends:
   - openssl >=3.1.1,<4.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 368167
@@ -7288,8 +6895,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7303,8 +6908,6 @@ packages:
   - libgcc >=13
   constrains:
   - expat 2.6.4.*
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -7317,8 +6920,6 @@ packages:
   - __osx >=10.13
   constrains:
   - expat 2.6.4.*
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -7331,8 +6932,6 @@ packages:
   - __osx >=11.0
   constrains:
   - expat 2.6.4.*
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 64693
@@ -7346,8 +6945,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - expat 2.6.4.*
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -7358,8 +6955,6 @@ packages:
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
   - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -7368,8 +6963,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
   sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
   md5: ccb34fb14960ad8b125962d3d79b31a9
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -7378,8 +6971,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
   md5: 086914b672be056eb70fd4285b6783b6
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 39020
@@ -7390,8 +6981,6 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -7406,8 +6995,6 @@ packages:
   constrains:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7418,8 +7005,6 @@ packages:
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
   - libgcc 14.2.0 h77fa898_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7432,8 +7017,6 @@ packages:
   - libgfortran5 14.2.0 hd5240d6_1
   constrains:
   - libgfortran-ng ==14.2.0=*_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7444,8 +7027,6 @@ packages:
   md5: 0b6e23a012ee7a9a5f6b244f5a92c1d5
   depends:
   - libgfortran5 13.2.0 h2873a65_3
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7456,8 +7037,6 @@ packages:
   md5: 4a55d9e169114b2b90d3ec4604cd7bbf
   depends:
   - libgfortran5 13.2.0 hf226fd6_3
-  arch: arm64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 110233
@@ -7469,8 +7048,6 @@ packages:
   - libgcc >=14.2.0
   constrains:
   - libgfortran 14.2.0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7483,8 +7060,6 @@ packages:
   - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 13_2_0_*_3
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7497,8 +7072,6 @@ packages:
   - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 13_2_0_*_3
-  arch: arm64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 997381
@@ -7515,8 +7088,6 @@ packages:
   - pcre2 >=10.44,<10.45.0a0
   constrains:
   - glib 2.82.2 *_0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   size: 3931898
   timestamp: 1729191404130
@@ -7525,8 +7096,6 @@ packages:
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -7547,8 +7116,6 @@ packages:
   - openssl >=3.4.0,<4.0a0
   constrains:
   - libgoogle-cloud 2.33.0 *_1
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7568,8 +7135,6 @@ packages:
   - openssl >=3.4.0,<4.0a0
   constrains:
   - libgoogle-cloud 2.33.0 *_1
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7589,8 +7154,6 @@ packages:
   - openssl >=3.4.0,<4.0a0
   constrains:
   - libgoogle-cloud 2.33.0 *_1
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 877594
@@ -7609,8 +7172,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - libgoogle-cloud 2.33.0 *_1
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7629,8 +7190,6 @@ packages:
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7648,8 +7207,6 @@ packages:
   - libgoogle-cloud 2.33.0 h7000a09_1
   - libzlib >=1.3.1,<2.0a0
   - openssl
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7667,8 +7224,6 @@ packages:
   - libgoogle-cloud 2.33.0 hdbe95d5_1
   - libzlib >=1.3.1,<2.0a0
   - openssl
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 526963
@@ -7685,8 +7240,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7709,8 +7262,6 @@ packages:
   - re2
   constrains:
   - grpc-cpp =1.67.1
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -7732,8 +7283,6 @@ packages:
   - re2
   constrains:
   - grpc-cpp =1.67.1
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -7755,8 +7304,6 @@ packages:
   - re2
   constrains:
   - grpc-cpp =1.67.1
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 5311706
@@ -7778,8 +7325,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - grpc-cpp =1.67.1
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -7794,8 +7339,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7806,8 +7349,6 @@ packages:
   md5: d66573916ffcf376178462f1b61c941e
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-only
   purls: []
   size: 705775
@@ -7815,8 +7356,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
   sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
   md5: 6c3628d047e151efba7cf08c5e54d1ca
-  arch: x86_64
-  platform: osx
   license: LGPL-2.1-only
   purls: []
   size: 666538
@@ -7824,8 +7363,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_2.conda
   sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
   md5: 69bda57310071cf6d2b86caf11573d2d
-  arch: arm64
-  platform: osx
   license: LGPL-2.1-only
   size: 676469
   timestamp: 1702682458114
@@ -7836,8 +7373,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-2.1-only
   purls: []
   size: 636146
@@ -7852,8 +7387,6 @@ packages:
   - libcblas 3.9.0 26_linux64_openblas
   - liblapacke 3.9.0 26_linux64_openblas
   - blas * openblas
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7869,8 +7402,6 @@ packages:
   - libcblas 3.9.0 26_osx64_openblas
   - blas * openblas
   - liblapacke 3.9.0 26_osx64_openblas
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7886,8 +7417,6 @@ packages:
   - liblapacke 3.9.0 26_osxarm64_openblas
   - libcblas 3.9.0 26_osxarm64_openblas
   - blas * openblas
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16624
@@ -7902,8 +7431,6 @@ packages:
   - liblapacke 3.9.0 26_win64_mkl
   - blas * mkl
   - libcblas 3.9.0 26_win64_mkl
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -7915,8 +7442,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: 0BSD
   purls: []
   size: 111132
@@ -7926,8 +7451,6 @@ packages:
   md5: f9e9205fed9c664421c1c09f0b90ce6d
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: 0BSD
   purls: []
   size: 103745
@@ -7937,8 +7460,6 @@ packages:
   md5: b2553114a7f5e20ccd02378a77d836aa
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: 0BSD
   size: 99129
   timestamp: 1733407496073
@@ -7949,8 +7470,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: 0BSD
   purls: []
   size: 104332
@@ -7961,8 +7480,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 89991
@@ -7972,8 +7489,6 @@ packages:
   md5: ed625b2e59dff82859c23dd24774156b
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 76561
@@ -7983,8 +7498,6 @@ packages:
   md5: 7476305c35dd9acef48da8f754eedb40
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 69263
@@ -7996,8 +7509,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-2-Clause
   license_family: BSD
   size: 88657
@@ -8014,8 +7525,6 @@ packages:
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -8032,8 +7541,6 @@ packages:
   - libev >=4.33,<5.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -8050,8 +7557,6 @@ packages:
   - libev >=4.33,<5.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 566719
@@ -8061,8 +7566,6 @@ packages:
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -8074,8 +7577,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 33418
@@ -8085,8 +7586,6 @@ packages:
   md5: 23d706dbe90b54059ad86ff826677f39
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: LGPL-2.1-or-later
   purls: []
   size: 33742
@@ -8096,8 +7595,6 @@ packages:
   md5: c90c1d3bd778f5ec0d4bb4ef36cbd5b6
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: LGPL-2.1-or-later
   size: 31099
   timestamp: 1734670168822
@@ -8111,8 +7608,6 @@ packages:
   - libgfortran5 >=14.2.0
   constrains:
   - openblas >=0.3.28,<0.3.29.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8128,8 +7623,6 @@ packages:
   - llvm-openmp >=18.1.8
   constrains:
   - openblas >=0.3.28,<0.3.29.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8145,8 +7638,6 @@ packages:
   - llvm-openmp >=18.1.8
   constrains:
   - openblas >=0.3.28,<0.3.29.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 4165774
@@ -8162,8 +7653,6 @@ packages:
   - libstdcxx >=13
   - libthrift >=0.21.0,<0.21.1.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   purls: []
   size: 1205598
@@ -8178,8 +7667,6 @@ packages:
   - libcxx >=18
   - libthrift >=0.21.0,<0.21.1.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   purls: []
   size: 943121
@@ -8194,8 +7681,6 @@ packages:
   - libcxx >=18
   - libthrift >=0.21.0,<0.21.1.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   size: 873251
   timestamp: 1735684582558
@@ -8210,8 +7695,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   purls: []
   size: 812887
@@ -8226,8 +7709,6 @@ packages:
   - libgcc >=13
   - openldap >=2.6.9,<2.7.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: PostgreSQL
   purls: []
   size: 2656919
@@ -8241,8 +7722,6 @@ packages:
   - krb5 >=1.21.3,<1.22.0a0
   - openldap >=2.6.9,<2.7.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: PostgreSQL
   purls: []
   size: 2604411
@@ -8256,8 +7735,6 @@ packages:
   - krb5 >=1.21.3,<1.22.0a0
   - openldap >=2.6.9,<2.7.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: arm64
-  platform: osx
   license: PostgreSQL
   size: 2649655
   timestamp: 1733428012273
@@ -8271,8 +7748,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: PostgreSQL
   purls: []
   size: 3971711
@@ -8287,8 +7762,6 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8303,8 +7776,6 @@ packages:
   - libabseil >=20240722.0,<20240723.0a0
   - libcxx >=18
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8319,8 +7790,6 @@ packages:
   - libabseil >=20240722.0,<20240723.0a0
   - libcxx >=18
   - libzlib >=1.3.1,<2.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 2271580
@@ -8335,8 +7804,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8353,8 +7820,6 @@ packages:
   - libstdcxx >=13
   constrains:
   - re2 2024.07.02.*
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8370,8 +7835,6 @@ packages:
   - libcxx >=18
   constrains:
   - re2 2024.07.02.*
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8387,8 +7850,6 @@ packages:
   - libcxx >=18
   constrains:
   - re2 2024.07.02.*
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 167155
@@ -8404,8 +7865,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - re2 2024.07.02.*
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8418,8 +7877,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: Unlicense
   purls: []
   size: 873551
@@ -8430,8 +7887,6 @@ packages:
   depends:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: osx
   license: Unlicense
   purls: []
   size: 923167
@@ -8442,8 +7897,6 @@ packages:
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
-  arch: arm64
-  platform: osx
   license: Unlicense
   size: 850553
   timestamp: 1733762057506
@@ -8454,8 +7907,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Unlicense
   purls: []
   size: 891292
@@ -8468,8 +7919,6 @@ packages:
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8482,8 +7931,6 @@ packages:
   - __osx >=10.13
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8495,8 +7942,6 @@ packages:
   depends:
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.4.0,<4.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 279028
@@ -8510,8 +7955,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8522,8 +7965,6 @@ packages:
   md5: 234a5554c53625688d51062645337328
   depends:
   - libgcc 14.2.0 h77fa898_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -8534,8 +7975,6 @@ packages:
   md5: 8371ac6457591af2cf6159439c1fd051
   depends:
   - libstdcxx 14.2.0 hc0a3c3a_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -8551,8 +7990,6 @@ packages:
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -8567,8 +8004,6 @@ packages:
   - libevent >=2.1.12,<2.1.13.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -8583,8 +8018,6 @@ packages:
   - libevent >=2.1.12,<2.1.13.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.3.2,<4.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 324342
@@ -8599,8 +8032,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -8612,8 +8043,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -8624,8 +8053,6 @@ packages:
   md5: 2c6188e92dbde6515162a84329c54f13
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -8636,8 +8063,6 @@ packages:
   md5: f777470d31c78cd0abe1903a2fda436f
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 83000
@@ -8649,8 +8074,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -8661,8 +8084,6 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -8676,8 +8097,6 @@ packages:
   constrains:
   - pthreads-win32 <0.0a0
   - msys2-conda-epoch <0.0a0
-  arch: x86_64
-  platform: win
   license: MIT AND BSD-3-Clause-Clear
   purls: []
   size: 35433
@@ -8687,8 +8106,6 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -8704,8 +8121,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   constrains:
   - icu <0.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 689993
@@ -8720,8 +8135,6 @@ packages:
   - libiconv >=1.17,<2.0a0
   - liblzma >=5.6.3,<6.0a0
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -8737,8 +8150,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   constrains:
   - icu <0.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 609081
@@ -8752,8 +8163,6 @@ packages:
   - libiconv >=1.17,<2.0a0
   - liblzma >=5.6.3,<6.0a0
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -8768,8 +8177,6 @@ packages:
   - libiconv >=1.17,<2.0a0
   - liblzma >=5.6.3,<6.0a0
   - libzlib >=1.3.1,<2.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 582898
@@ -8783,8 +8190,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -8798,8 +8203,6 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -8812,8 +8215,6 @@ packages:
   - __osx >=10.13
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: osx
   license: Zlib
   license_family: Other
   purls: []
@@ -8826,8 +8227,6 @@ packages:
   - __osx >=11.0
   constrains:
   - zlib 1.3.1 *_2
-  arch: arm64
-  platform: osx
   license: Zlib
   license_family: Other
   size: 46438
@@ -8841,8 +8240,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: win
   license: Zlib
   license_family: Other
   purls: []
@@ -8855,8 +8252,6 @@ packages:
   - __osx >=10.13
   constrains:
   - openmp 19.1.6|19.1.6.*
-  arch: x86_64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
@@ -8869,8 +8264,6 @@ packages:
   - __osx >=11.0
   constrains:
   - openmp 19.1.6|19.1.6.*
-  arch: arm64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   size: 281251
@@ -8882,8 +8275,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -8895,8 +8286,6 @@ packages:
   depends:
   - __osx >=10.13
   - libcxx >=18
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -8908,8 +8297,6 @@ packages:
   depends:
   - __osx >=11.0
   - libcxx >=18
-  arch: arm64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 148824
@@ -8921,8 +8308,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -8948,8 +8333,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - jinja2 >=3.0.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 24856
@@ -8963,8 +8346,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - jinja2 >=3.0.0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 24363
@@ -8979,8 +8360,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - jinja2 >=3.0.0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 24757
@@ -8996,8 +8375,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - jinja2 >=3.0.0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 27930
@@ -9027,8 +8404,6 @@ packages:
   depends:
   - intel-openmp 2024.*
   - tbb 2021.*
-  arch: x86_64
-  platform: win
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   purls: []
@@ -9064,8 +8439,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 889086
@@ -9075,8 +8448,6 @@ packages:
   md5: e102bbf8a6ceeaf429deab8032fc8977
   depends:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: X11 AND BSD-3-Clause
   purls: []
   size: 822066
@@ -9086,8 +8457,6 @@ packages:
   md5: cb2b0ea909b97b3d70cd3921d1445e1a
   depends:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: X11 AND BSD-3-Clause
   size: 802321
   timestamp: 1724658775723
@@ -9101,8 +8470,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 638978
@@ -9116,8 +8483,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 566137
@@ -9132,8 +8497,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 557141
@@ -9147,8 +8510,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 466870
@@ -9179,8 +8540,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 7912254
@@ -9199,8 +8558,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 9014710
@@ -9219,8 +8576,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9241,8 +8596,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 8478406
@@ -9260,8 +8613,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 7071469
@@ -9279,8 +8630,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 8223937
@@ -9298,8 +8647,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9319,8 +8666,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 7643198
@@ -9339,8 +8684,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - numpy-base <0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 5929029
@@ -9359,8 +8702,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - numpy-base <0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 7067777
@@ -9379,8 +8720,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - numpy-base <0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6495249
@@ -9399,8 +8738,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - numpy-base <0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6513050
@@ -9419,8 +8756,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 6420026
@@ -9439,8 +8774,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 7682709
@@ -9459,8 +8792,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9481,8 +8812,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 7147174
@@ -9497,8 +8826,6 @@ packages:
   - libgcc >=13
   - libstdcxx >=13
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: OLDAP-2.8
   license_family: BSD
   purls: []
@@ -9513,8 +8840,6 @@ packages:
   - krb5 >=1.21.3,<1.22.0a0
   - libcxx >=18
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: OLDAP-2.8
   license_family: BSD
   purls: []
@@ -9529,8 +8854,6 @@ packages:
   - krb5 >=1.21.3,<1.22.0a0
   - libcxx >=18
   - openssl >=3.4.0,<4.0a0
-  arch: arm64
-  platform: osx
   license: OLDAP-2.8
   license_family: BSD
   size: 842504
@@ -9542,8 +8865,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9555,8 +8876,6 @@ packages:
   depends:
   - __osx >=10.13
   - ca-certificates
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9568,8 +8887,6 @@ packages:
   depends:
   - __osx >=11.0
   - ca-certificates
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 2935176
@@ -9582,8 +8899,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9602,8 +8917,6 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - tzdata
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9621,8 +8934,6 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - tzdata
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9640,8 +8951,6 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - tzdata
   - zstd >=1.5.6,<1.6.0a0
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 438520
@@ -9659,8 +8968,6 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -9691,8 +8998,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.10.* *_cp310
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 13014228
@@ -9711,8 +9016,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.11.* *_cp311
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 15695466
@@ -9731,8 +9034,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9753,8 +9054,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.13.* *_cp313
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 15407410
@@ -9772,8 +9071,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.10.* *_cp310
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 12209035
@@ -9791,8 +9088,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.11.* *_cp311
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14864168
@@ -9810,8 +9105,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9831,8 +9124,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.13.* *_cp313
   - pytz >=2020.1,<2024.2
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14632093
@@ -9851,8 +9142,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.10.* *_cp310
   - pytz >=2020.1,<2024.2
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 12024352
@@ -9871,8 +9160,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.11.* *_cp311
   - pytz >=2020.1,<2024.2
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14807397
@@ -9891,8 +9178,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1,<2024.2
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14470437
@@ -9911,8 +9196,6 @@ packages:
   - python-tzdata >=2022a
   - python_abi 3.13.* *_cp313
   - pytz >=2020.1,<2024.2
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14464446
@@ -9931,8 +9214,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 11810567
@@ -9951,8 +9232,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 14587131
@@ -9971,8 +9250,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -9993,8 +9270,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 14215159
@@ -10028,8 +9303,6 @@ packages:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 952308
@@ -10131,8 +9404,6 @@ packages:
   - typing_extensions >=4.0.0
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 25432329
@@ -10149,8 +9420,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 25677341
@@ -10167,8 +9436,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -10187,8 +9454,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 25657717
@@ -10205,8 +9470,6 @@ packages:
   - typing_extensions >=4.0.0
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 24366867
@@ -10222,8 +9485,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 24594316
@@ -10239,8 +9500,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -10258,8 +9517,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 24584424
@@ -10277,8 +9534,6 @@ packages:
   - typing_extensions >=4.0.0
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22343069
@@ -10295,8 +9550,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22600615
@@ -10313,8 +9566,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22496527
@@ -10331,8 +9582,6 @@ packages:
   - python_abi 3.13.* *_cp313
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22563994
@@ -10349,8 +9598,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 26995126
@@ -10366,8 +9613,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 27087972
@@ -10383,8 +9628,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -10402,8 +9645,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.3
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 27010933
@@ -10446,8 +9687,6 @@ packages:
   - libpq >=17.0,<18.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 174274
@@ -10461,8 +9700,6 @@ packages:
   - libpq >=17.0,<18.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 190799
@@ -10476,8 +9713,6 @@ packages:
   - libpq >=17.0,<18.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls:
@@ -10493,8 +9728,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 150442
@@ -10508,8 +9741,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 166999
@@ -10523,8 +9754,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls:
@@ -10541,8 +9770,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 150972
@@ -10557,8 +9784,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 165816
@@ -10573,8 +9798,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 165451
@@ -10590,8 +9813,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 157831
@@ -10607,8 +9828,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-3.0-or-later
   license_family: LGPL
   size: 173963
@@ -10624,8 +9843,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-3.0-or-later
   license_family: LGPL
   purls:
@@ -10651,8 +9868,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 25169
@@ -10668,8 +9883,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 25199
@@ -10685,8 +9898,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -10703,8 +9914,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 25179
@@ -10720,8 +9929,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25316
@@ -10737,8 +9944,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25275
@@ -10754,8 +9959,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -10772,8 +9975,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25331
@@ -10789,8 +9990,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25411
@@ -10806,8 +10005,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25322
@@ -10823,8 +10020,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25375
@@ -10840,8 +10035,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 25382
@@ -10857,8 +10050,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 25680
@@ -10874,8 +10065,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 25662
@@ -10891,8 +10080,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -10909,8 +10096,6 @@ packages:
   - pyarrow-core 18.1.0 *_0_*
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 25682
@@ -10929,8 +10114,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 4544985
@@ -10949,8 +10132,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 4562010
@@ -10969,8 +10150,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -10991,8 +10170,6 @@ packages:
   constrains:
   - apache-arrow-proc =*=cpu
   - numpy >=1.21,<3
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 4591002
@@ -11010,8 +10187,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3975033
@@ -11029,8 +10204,6 @@ packages:
   constrains:
   - apache-arrow-proc =*=cpu
   - numpy >=1.21,<3
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 4068983
@@ -11048,8 +10221,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -11069,8 +10240,6 @@ packages:
   constrains:
   - apache-arrow-proc =*=cpu
   - numpy >=1.21,<3
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 4027883
@@ -11089,8 +10258,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3881631
@@ -11109,8 +10276,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3974075
@@ -11129,8 +10294,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3909116
@@ -11149,8 +10312,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   size: 3904587
@@ -11169,8 +10330,6 @@ packages:
   constrains:
   - apache-arrow-proc =*=cpu
   - numpy >=1.21,<3
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 3425932
@@ -11189,8 +10348,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 3498372
@@ -11209,8 +10366,6 @@ packages:
   constrains:
   - apache-arrow-proc =*=cpu
   - numpy >=1.21,<3
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -11231,8 +10386,6 @@ packages:
   constrains:
   - numpy >=1.21,<3
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 3411909
@@ -11248,6 +10401,18 @@ packages:
   purls: []
   size: 110100
   timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydiverse-common-0.1.0-pyh29332c3_0.conda
+  sha256: 62520ce1a38348d678b228a4ea4f10f3aa2982b74a8097caaccd54832796e592
+  md5: 18e14d5630610d418e96040f2e953727
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pydiverse-common?source=hash-mapping
+  size: 13406
+  timestamp: 1744279711481
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
   sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
   md5: b38dc0206e2a530e5c2cf11dc086b31a
@@ -11267,8 +10432,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 77791
@@ -11283,8 +10446,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 78141
@@ -11299,8 +10460,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -11316,8 +10475,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 70793
@@ -11331,8 +10488,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 71078
@@ -11346,8 +10501,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -11364,8 +10517,6 @@ packages:
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 71545
@@ -11380,8 +10531,6 @@ packages:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 71302
@@ -11396,8 +10545,6 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   - unixodbc >=2.3.12,<2.4.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 72448
@@ -11411,8 +10558,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 69049
@@ -11426,8 +10571,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 69244
@@ -11441,8 +10584,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -11527,8 +10668,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   size: 25199631
   timestamp: 1733409331823
@@ -11556,8 +10695,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   size: 30624804
   timestamp: 1733409665928
@@ -11585,8 +10722,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 31565686
@@ -11613,8 +10748,6 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   size: 33263183
   timestamp: 1733436074842
@@ -11636,8 +10769,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: Python-2.0
   size: 13061363
   timestamp: 1733408434547
@@ -11660,8 +10791,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: Python-2.0
   size: 14221518
   timestamp: 1733409959819
@@ -11684,8 +10813,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: Python-2.0
   purls: []
   size: 13683139
@@ -11709,8 +10836,6 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  arch: x86_64
-  platform: osx
   license: Python-2.0
   size: 14067313
   timestamp: 1733434634823
@@ -11732,8 +10857,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: Python-2.0
   size: 12372048
   timestamp: 1733408850559
@@ -11756,8 +10879,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: Python-2.0
   size: 14647146
   timestamp: 1733409012105
@@ -11780,8 +10901,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: Python-2.0
   size: 12998673
   timestamp: 1733408900971
@@ -11804,8 +10923,6 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  arch: arm64
-  platform: osx
   license: Python-2.0
   size: 12905237
   timestamp: 1733433280639
@@ -11827,8 +10944,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: win
   license: Python-2.0
   size: 16061214
   timestamp: 1733408154785
@@ -11851,8 +10966,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: win
   license: Python-2.0
   size: 18161635
   timestamp: 1733408064601
@@ -11875,8 +10988,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: win
   license: Python-2.0
   purls: []
   size: 15812363
@@ -11900,8 +11011,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Python-2.0
   size: 16753813
   timestamp: 1733433028707
@@ -11926,8 +11035,6 @@ packages:
   - libstdcxx >=13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 24267398
@@ -11941,8 +11048,6 @@ packages:
   - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 24287914
@@ -11956,8 +11061,6 @@ packages:
   - libstdcxx >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -11972,8 +11075,6 @@ packages:
   - libcxx >=18
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22035457
@@ -11986,8 +11087,6 @@ packages:
   - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 22069406
@@ -12000,8 +11099,6 @@ packages:
   - libcxx >=18
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -12017,8 +11114,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 20398771
@@ -12032,8 +11127,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 20434175
@@ -12047,8 +11140,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 20461817
@@ -12062,8 +11153,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 16945750
@@ -12077,8 +11166,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 17033885
@@ -12092,8 +11179,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -12117,8 +11202,6 @@ packages:
   md5: 2921c34715e74b3587b4cff4d36844f9
   constrains:
   - python 3.10.* *_cpython
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 6227
@@ -12129,8 +11212,6 @@ packages:
   md5: 139a8d40c8a2f430df31048949e450de
   constrains:
   - python 3.11.* *_cpython
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 6211
@@ -12141,8 +11222,6 @@ packages:
   md5: 0424ae29b104430108f5218a66db7260
   constrains:
   - python 3.12.* *_cpython
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12154,8 +11233,6 @@ packages:
   md5: 381bbd2a92c863f640a55b6ff3c35161
   constrains:
   - python 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 6217
@@ -12166,8 +11243,6 @@ packages:
   md5: 5918a11cbc8e1650b2dde23b6ef7452c
   constrains:
   - python 3.10.* *_cpython
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6319
@@ -12178,8 +11253,6 @@ packages:
   md5: e6d62858c06df0be0e6255c753d74787
   constrains:
   - python 3.11.* *_cpython
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6303
@@ -12190,8 +11263,6 @@ packages:
   md5: c34dd4920e0addf7cfcc725809f25d8e
   constrains:
   - python 3.12.* *_cpython
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12203,8 +11274,6 @@ packages:
   md5: 927a2186f1f997ac018d67c4eece90a6
   constrains:
   - python 3.13.* *_cp313
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6291
@@ -12215,8 +11284,6 @@ packages:
   md5: e33836c9096802b29d28981765becbee
   constrains:
   - python 3.10.* *_cpython
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6324
@@ -12227,8 +11294,6 @@ packages:
   md5: 3b855e3734344134cb56c410f729c340
   constrains:
   - python 3.11.* *_cpython
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6308
@@ -12239,8 +11304,6 @@ packages:
   md5: b76f9b1c862128e56ac7aa8cd2333de9
   constrains:
   - python 3.12.* *_cpython
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6278
@@ -12251,8 +11314,6 @@ packages:
   md5: b8e82d0a5c1664638f87f63cc5d241fb
   constrains:
   - python 3.13.* *_cp313
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 6322
@@ -12263,8 +11324,6 @@ packages:
   md5: 3c510f4c4383f5fbdb12fdd971b30d49
   constrains:
   - python 3.10.* *_cpython
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 6715
@@ -12275,8 +11334,6 @@ packages:
   md5: 895b873644c11ccc0ab7dba2d8513ae6
   constrains:
   - python 3.11.* *_cpython
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 6707
@@ -12287,8 +11344,6 @@ packages:
   md5: e8681f534453af7afab4cd2bc1423eec
   constrains:
   - python 3.12.* *_cpython
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12300,8 +11355,6 @@ packages:
   md5: 44b4fe6f22b57103afb2299935c8b68e
   constrains:
   - python 3.13.* *_cp313
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 6716
@@ -12323,8 +11376,6 @@ packages:
   depends:
   - python >=3.13.0rc2,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 57565
@@ -12338,8 +11389,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 182609
@@ -12353,8 +11402,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 212644
@@ -12368,8 +11415,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -12385,8 +11430,6 @@ packages:
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 205855
@@ -12399,8 +11442,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 164184
@@ -12413,8 +11454,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 193941
@@ -12427,8 +11466,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -12443,8 +11480,6 @@ packages:
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 190014
@@ -12458,8 +11493,6 @@ packages:
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   - yaml >=0.2.5,<0.3.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 162312
@@ -12473,8 +11506,6 @@ packages:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - yaml >=0.2.5,<0.3.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 192321
@@ -12488,8 +11519,6 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 187143
@@ -12503,8 +11532,6 @@ packages:
   - python >=3.13.0rc1,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
   - yaml >=0.2.5,<0.3.0a0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 187550
@@ -12519,8 +11546,6 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 156987
@@ -12535,8 +11560,6 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 187901
@@ -12551,8 +11574,6 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -12569,8 +11590,6 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 181722
@@ -12580,8 +11599,6 @@ packages:
   md5: e84ddf12bde691e8ec894b00ea829ddf
   depends:
   - libre2-11 2024.07.02 hbbce691_2
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12592,8 +11609,6 @@ packages:
   md5: 5fd6022c97d78c252f1cc8d7433e97d0
   depends:
   - libre2-11 2024.07.02 h0e468a2_2
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12604,8 +11619,6 @@ packages:
   md5: 7a8b4ad8c58a3408ca89d78788c78178
   depends:
   - libre2-11 2024.07.02 h07bc746_2
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 26861
@@ -12615,8 +11628,6 @@ packages:
   md5: 10980cbe103147435a40288db9f49847
   depends:
   - libre2-11 2024.07.02 h4eb7d71_2
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -12628,8 +11639,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -12640,8 +11649,6 @@ packages:
   md5: f17f77f2acf4d344734bda76829ce14e
   depends:
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -12652,8 +11659,6 @@ packages:
   md5: 8cbb776a2f641b943d413b3e19df71f4
   depends:
   - ncurses >=6.3,<7.0a0
-  arch: arm64
-  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   size: 250351
@@ -12726,8 +11731,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 202717
@@ -12741,8 +11744,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 273498
@@ -12756,8 +11757,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -12772,8 +11771,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 202780
@@ -12786,8 +11783,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 274075
@@ -12800,8 +11795,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -12817,8 +11810,6 @@ packages:
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   - ruamel.yaml.clib >=0.1.2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 202965
@@ -12832,8 +11823,6 @@ packages:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - ruamel.yaml.clib >=0.1.2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 272806
@@ -12847,8 +11836,6 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 268321
@@ -12863,8 +11850,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 203584
@@ -12879,8 +11864,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 273479
@@ -12895,8 +11878,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -12911,8 +11892,6 @@ packages:
   - libgcc >=13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 146766
@@ -12925,8 +11904,6 @@ packages:
   - libgcc >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 147191
@@ -12939,8 +11916,6 @@ packages:
   - libgcc >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -12954,8 +11929,6 @@ packages:
   - __osx >=10.13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 120704
@@ -12967,8 +11940,6 @@ packages:
   - __osx >=10.13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 120842
@@ -12980,8 +11951,6 @@ packages:
   - __osx >=10.13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -12996,8 +11965,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 117070
@@ -13010,8 +11977,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 117234
@@ -13024,8 +11989,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 117121
@@ -13039,8 +12002,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 110494
@@ -13054,8 +12015,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 110651
@@ -13069,8 +12028,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -13088,8 +12045,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 7941475
@@ -13105,8 +12060,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 7942769
@@ -13122,8 +12075,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -13140,8 +12091,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 7331215
@@ -13156,8 +12105,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 7322273
@@ -13172,8 +12119,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -13191,8 +12136,6 @@ packages:
   - python_abi 3.10.* *_cp310
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 6989403
@@ -13208,8 +12151,6 @@ packages:
   - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 6992953
@@ -13225,8 +12166,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 6989865
@@ -13240,8 +12179,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 6929654
@@ -13255,8 +12192,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 6936915
@@ -13270,8 +12205,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -13285,8 +12218,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - openssl >=3.4.0,<4.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -13301,8 +12232,6 @@ packages:
   - jeepney >=0.6
   - python >=3.13.0rc1,<3.14.0a0
   - python_abi 3.13.* *_cp313
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 32074
@@ -13345,8 +12274,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -13358,8 +12285,6 @@ packages:
   depends:
   - __osx >=10.13
   - libcxx >=18
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -13371,8 +12296,6 @@ packages:
   depends:
   - __osx >=11.0
   - libcxx >=18
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 35857
@@ -13384,8 +12307,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -13544,8 +12465,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 2804881
@@ -13560,8 +12479,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 3575665
@@ -13576,8 +12493,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -13594,8 +12509,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 3605771
@@ -13609,8 +12522,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 2770491
@@ -13624,8 +12535,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3522033
@@ -13639,8 +12548,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -13656,8 +12563,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - typing-extensions >=4.6.0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3573031
@@ -13672,8 +12577,6 @@ packages:
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   - typing-extensions >=4.6.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 2805289
@@ -13688,8 +12591,6 @@ packages:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3475302
@@ -13704,8 +12605,6 @@ packages:
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3439373
@@ -13720,8 +12619,6 @@ packages:
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
   - typing-extensions >=4.6.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3561027
@@ -13737,8 +12634,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 2795495
@@ -13754,8 +12649,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 3496905
@@ -13771,8 +12664,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -13790,8 +12681,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 3534660
@@ -13805,8 +12694,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -13820,8 +12707,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -13835,8 +12720,6 @@ packages:
   - openssl >=3.3.2,<4.0a0
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 3522930
@@ -13848,8 +12731,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -13863,8 +12744,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls: []
@@ -13876,8 +12755,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: linux
   license: TCL
   license_family: BSD
   purls: []
@@ -13888,8 +12765,6 @@ packages:
   md5: bf830ba5afc507c6232d4ef0fb1a882d
   depends:
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: osx
   license: TCL
   license_family: BSD
   purls: []
@@ -13900,8 +12775,6 @@ packages:
   md5: b50a57ba89c32b62428b71a875291c9b
   depends:
   - libzlib >=1.2.13,<2.0.0a0
-  arch: arm64
-  platform: osx
   license: TCL
   license_family: BSD
   size: 3145523
@@ -13913,8 +12786,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: TCL
   license_family: BSD
   purls: []
@@ -14009,8 +12880,6 @@ packages:
   - libgcc >=13
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -14023,8 +12892,6 @@ packages:
   - __osx >=10.13
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -14037,8 +12904,6 @@ packages:
   - __osx >=11.0
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 2979971
@@ -14050,8 +12915,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -14069,8 +12932,6 @@ packages:
   md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
   - vs2015_runtime >=14.29.30037
-  arch: x86_64
-  platform: win
   license: LicenseRef-MicrosoftWindowsSDK10
   purls: []
   size: 559710
@@ -14085,8 +12946,6 @@ packages:
   - libstdcxx >=13
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 13756
@@ -14101,8 +12960,6 @@ packages:
   - libstdcxx >=13
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 13858
@@ -14117,8 +12974,6 @@ packages:
   - libstdcxx >=13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls:
@@ -14134,8 +12989,6 @@ packages:
   - libcxx >=17
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 12925
@@ -14149,8 +13002,6 @@ packages:
   - libcxx >=17
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 13060
@@ -14164,8 +13015,6 @@ packages:
   - libcxx >=17
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -14182,8 +13031,6 @@ packages:
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 13565
@@ -14198,8 +13045,6 @@ packages:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 13603
@@ -14214,8 +13059,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 13605
@@ -14230,8 +13073,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 17065
@@ -14246,8 +13087,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 17253
@@ -14262,8 +13101,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls:
@@ -14278,8 +13115,6 @@ packages:
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1
   purls: []
   size: 281830
@@ -14291,8 +13126,6 @@ packages:
   - libcxx >=15.0.7
   - libedit >=3.1.20191231,<3.2.0a0
   - libiconv >=1.17,<2.0a0
-  arch: x86_64
-  platform: osx
   license: LGPL-2.1
   purls: []
   size: 259234
@@ -14304,8 +13137,6 @@ packages:
   - libcxx >=15.0.7
   - libedit >=3.1.20191231,<3.2.0a0
   - libiconv >=1.17,<2.0a0
-  arch: arm64
-  platform: osx
   license: LGPL-2.1
   size: 253937
   timestamp: 1691504579753
@@ -14341,8 +13172,6 @@ packages:
   - libstdcxx >=13
   constrains:
   - __glibc >=2.17
-  arch: x86_64
-  platform: linux
   license: Apache-2.0 OR MIT
   size: 10629639
   timestamp: 1735323867172
@@ -14354,8 +13183,6 @@ packages:
   - libcxx >=18
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: Apache-2.0 OR MIT
   size: 10266392
   timestamp: 1735324517513
@@ -14367,8 +13194,6 @@ packages:
   - libcxx >=18
   constrains:
   - __osx >=11.0
-  arch: arm64
-  platform: osx
   license: Apache-2.0 OR MIT
   size: 10310622
   timestamp: 1735324466028
@@ -14379,8 +13204,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0 OR MIT
   size: 11505540
   timestamp: 1735325260758
@@ -14389,8 +13212,6 @@ packages:
   md5: 7c10ec3158d1eb4ddff7007c9101adb0
   depends:
   - vc14_runtime >=14.38.33135
-  arch: x86_64
-  platform: win
   track_features:
   - vc14
   license: BSD-3-Clause
@@ -14405,8 +13226,6 @@ packages:
   - ucrt >=10.0.20348.0
   constrains:
   - vs2015_runtime 14.42.34433.* *_23
-  arch: x86_64
-  platform: win
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   purls: []
@@ -14431,8 +13250,6 @@ packages:
   md5: 5c176975ca2b8366abad3c97b3cd1e83
   depends:
   - vc14_runtime >=14.42.34433
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -14463,8 +13280,6 @@ packages:
   md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
   depends:
   - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -14473,8 +13288,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
   sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
   md5: d7e08fcf8259d742156188e8762b4d20
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls: []
@@ -14483,8 +13296,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
   sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
   md5: 4bb3f014845110883a3c5ee811fd84b4
-  arch: arm64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 88016
@@ -14495,8 +13306,6 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   purls: []
@@ -14524,8 +13333,6 @@ packages:
   - python_abi 3.13.* *_cp313
   - zstd >=1.5.6,<1.5.7.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 424424
@@ -14540,8 +13347,6 @@ packages:
   - python_abi 3.13.* *_cp313
   - zstd >=1.5.6,<1.5.7.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 417943
@@ -14557,8 +13362,6 @@ packages:
   - python_abi 3.13.* *_cp313
   - zstd >=1.5.6,<1.5.7.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 336496
@@ -14575,8 +13378,6 @@ packages:
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.6,<1.5.7.0a0
   - zstd >=1.5.6,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 325703
@@ -14588,8 +13389,6 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -14601,8 +13400,6 @@ packages:
   depends:
   - __osx >=10.9
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -14614,8 +13411,6 @@ packages:
   depends:
   - __osx >=11.0
   - libzlib >=1.2.13,<2.0.0a0
-  arch: arm64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 405089
@@ -14628,8 +13423,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   purls: []

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,10 +5,11 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 
 [dependencies]
 python = ">=3.10"
-pandas = ">=2.0.0"     # only required for SQL writing
+pandas = ">=2.0.0"           # only required for SQL writing
 SQLAlchemy = ">=2.0.0"
 pyarrow = ">=11.0.0"
 polars = ">=1.6.0"
+pydiverse-common = ">=0.1.0"
 
 [host-dependencies]
 pip = "*"
@@ -58,7 +59,7 @@ Sphinx = ">=7.3.7"
 furo = ">=2023.5.20"
 sphinxcontrib-apidoc = ">=0.3.0"
 myst-parser = ">=2.0.0"
-sphinx-autosummary-accessors = "2023.4.0"
+sphinx-autosummary-accessors = "2023.4.0.*"
 [feature.docs.tasks]
 docs = "cd docs && make html "
 readthedocs = "rm -rf $READTHEDOCS_OUTPUT/html && cp -r docs/build/html $READTHEDOCS_OUTPUT/html"

--- a/src/pydiverse/transform/__init__.py
+++ b/src/pydiverse/transform/__init__.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from ._internal.pipe.pipeable import verb
-from ._internal.pipe.table import Table
+from ._internal.pipe.table import Table, backend, is_sql_backed
 from ._internal.tree.col_expr import Col, ColExpr
 from .extended import *
 from .extended import __all__ as __extended
 from .types import *
 from .types import __all__ as __types
 
-__all__ = ["Table", "ColExpr", "Col", "verb"] + __extended + __types
+__all__ = (
+    ["Table", "ColExpr", "Col", "verb", "backend", "is_sql_backed"]
+    + __extended
+    + __types
+)

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -19,6 +19,8 @@ from pydiverse.transform._internal.tree.types import Int64
 
 
 class DuckDbImpl(SqlImpl):
+    backend_name = "duckdb"
+
     @classmethod
     def export(
         cls,

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -51,7 +51,7 @@ class DuckDbImpl(SqlImpl):
         return super().compile_lit(lit)
 
     @classmethod
-    def past_over_clause(
+    def fix_fn_types(
         cls, fn: sql.ColFn, val: sqa.ColumnElement, *args: sqa.ColumnElement
     ) -> sqa.ColumnElement:
         if fn.op == ops.sum:

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -13,7 +13,7 @@ from pydiverse.transform._internal.backend.targets import Polars, Target
 from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.ast import AstNode
-from pydiverse.transform._internal.tree.col_expr import Cast, Col, LiteralCol
+from pydiverse.transform._internal.tree.col_expr import Cast, LiteralCol
 from pydiverse.transform._internal.tree.types import Int64
 
 
@@ -23,18 +23,17 @@ class DuckDbImpl(SqlImpl):
         cls,
         nd: AstNode,
         target: Target,
-        final_select: list[Col],
         schema_overrides: dict[str, Any],
     ):
         if isinstance(target, Polars):
             engine = sql.get_engine(nd)
             with engine.connect() as conn:
                 return pl.read_database(
-                    DuckDbImpl.build_query(nd, final_select),
+                    DuckDbImpl.build_query(nd),
                     connection=conn,
                     schema_overrides=schema_overrides,
                 )
-        return SqlImpl.export(nd, target, final_select, schema_overrides)
+        return SqlImpl.export(nd, target, schema_overrides)
 
     @classmethod
     def compile_cast(cls, cast: Cast, sqa_col: dict[str, sqa.Label]) -> Cast:

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -8,6 +8,7 @@ import sqlalchemy as sqa
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.sql.type_api import TypeEngine as TypeEngine
 
+from pydiverse.common import Int64
 from pydiverse.transform._internal.backend import sql
 from pydiverse.transform._internal.backend.sql import SqlImpl
 from pydiverse.transform._internal.backend.targets import Polars, Target
@@ -15,7 +16,6 @@ from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.ast import AstNode
 from pydiverse.transform._internal.tree.col_expr import Cast, LiteralCol
-from pydiverse.transform._internal.tree.types import Int64
 
 
 class DuckDbImpl(SqlImpl):

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -90,3 +90,7 @@ with DuckDbImpl.impl_store.impl_manager as impl:
     @impl(ops.str_join)
     def _str_join(x, delim):
         return sqa.func.string_agg(x, delim)
+
+    @impl(ops.list_agg)
+    def _list_agg(x):
+        return sqa.func.array_agg(x)

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import polars as pl
 import sqlalchemy as sqa
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.sql.type_api import TypeEngine as TypeEngine
 
 from pydiverse.transform._internal.backend import sql
@@ -56,6 +57,12 @@ class DuckDbImpl(SqlImpl):
         if fn.op == ops.sum:
             return sqa.cast(val, type_=args[0].type)
         return val
+
+    @classmethod
+    def compile_ordered_aggregation(
+        cls, *args: sqa.ColumnElement, order_by: list[sqa.UnaryExpression], impl
+    ) -> sqa.ColumnElement:
+        return impl(*args[:-1], aggregate_order_by(args[-1], *order_by))
 
 
 with DuckDbImpl.impl_store.impl_manager as impl:

--- a/src/pydiverse/transform/_internal/backend/duckdb.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 import polars as pl
 import sqlalchemy as sqa
@@ -23,7 +24,8 @@ class DuckDbImpl(SqlImpl):
         cls,
         nd: AstNode,
         target: Target,
-        schema_overrides: dict[str, Any],
+        *,
+        schema_overrides: dict[UUID, Any],
     ):
         if isinstance(target, Polars):
             engine = sql.get_engine(nd)
@@ -33,7 +35,7 @@ class DuckDbImpl(SqlImpl):
                     connection=conn,
                     schema_overrides=schema_overrides,
                 )
-        return SqlImpl.export(nd, target, schema_overrides)
+        return SqlImpl.export(nd, target, schema_overrides=schema_overrides)
 
     @classmethod
     def compile_cast(cls, cast: Cast, sqa_col: dict[str, sqa.Label]) -> Cast:

--- a/src/pydiverse/transform/_internal/backend/duckdb_polars.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb_polars.py
@@ -49,7 +49,7 @@ class DuckDbPolarsImpl(TableImpl):
         nd: AstNode,
         target: Target,
         *,
-        schema_overrides: dict[str, Any],  # TODO: use this
+        schema_overrides: dict[UUID, Any],  # TODO: use this
     ) -> pl.DataFrame:
         if isinstance(target, Polars):
             sel = DuckDbImpl.build_select(nd)

--- a/src/pydiverse/transform/_internal/backend/duckdb_polars.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb_polars.py
@@ -20,6 +20,8 @@ from pydiverse.transform._internal.tree.ast import AstNode
 # Currently it works only since this class also has a table object, but it should be
 # enforced by inheritance.
 class DuckDbPolarsImpl(TableImpl):
+    backend_name = "polars"
+
     def __init__(self, name: str, df: pl.DataFrame | pl.LazyFrame):
         self.df = df if isinstance(df, pl.LazyFrame) else df.lazy()
 

--- a/src/pydiverse/transform/_internal/backend/duckdb_polars.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb_polars.py
@@ -13,7 +13,6 @@ from pydiverse.transform._internal.backend.duckdb import DuckDbImpl
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.backend.targets import Polars, Target
 from pydiverse.transform._internal.tree.ast import AstNode
-from pydiverse.transform._internal.tree.col_expr import Col
 
 
 # TODO: we should move the engine of SqlImpl in the subclasses and let this thing
@@ -42,18 +41,18 @@ class DuckDbPolarsImpl(TableImpl):
         )
 
     @staticmethod
-    def build_query(nd: AstNode, final_select: list[Col]) -> str | None:
-        return DuckDbImpl.build_query(nd, final_select, dialect=duckdb_engine.Dialect())
+    def build_query(nd: AstNode) -> str | None:
+        return DuckDbImpl.build_query(nd, dialect=duckdb_engine.Dialect())
 
     @staticmethod
     def export(
         nd: AstNode,
         target: Target,
-        final_select: list[Col],
-        schema_overrides: dict[str, Any],
+        *,
+        schema_overrides: dict[str, Any],  # TODO: use this
     ) -> pl.DataFrame:
         if isinstance(target, Polars):
-            sel = DuckDbImpl.build_select(nd, final_select)
+            sel = DuckDbImpl.build_select(nd)
             query_str = str(
                 sel.compile(
                     dialect=duckdb_engine.Dialect(),

--- a/src/pydiverse/transform/_internal/backend/duckdb_polars.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb_polars.py
@@ -8,7 +8,7 @@ import duckdb_engine
 import polars as pl
 import sqlalchemy as sqa
 
-from pydiverse.transform._internal.backend import polars
+from pydiverse.common import Dtype
 from pydiverse.transform._internal.backend.duckdb import DuckDbImpl
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.backend.targets import Polars, Target
@@ -27,7 +27,7 @@ class DuckDbPolarsImpl(TableImpl):
         super().__init__(
             name,
             {
-                name: polars.pdt_type(dtype)
+                name: Dtype.from_polars(dtype)
                 for name, dtype in df.collect_schema().items()
             },
         )

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -85,17 +85,13 @@ def convert_order_list(order_list: list[Order]) -> list[Order]:
     for ord in order_list:
         # is True / is False are important here since we don't want to do this costly
         # workaround if nulls_last is None (i.e. the user doesn't care)
-        if ord.nulls_last is True and not ord.descending:
+        if ord.nulls_last is not None and (ord.nulls_last ^ ord.descending):
             new_list.append(
                 Order(
-                    CaseExpr([(ord.order_by.is_null(), LiteralCol(1))], LiteralCol(0)),
-                )
-            )
-
-        elif ord.nulls_last is False and ord.descending:
-            new_list.append(
-                Order(
-                    CaseExpr([(ord.order_by.is_null(), LiteralCol(0))], LiteralCol(1)),
+                    CaseExpr(
+                        [(ord.order_by.is_null(), LiteralCol(int(ord.nulls_last)))],
+                        LiteralCol(int(not ord.nulls_last)),
+                    )
                 )
             )
 

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -83,6 +83,12 @@ class MsSqlImpl(SqlImpl):
         table, query, _ = cls.compile_ast(nd, {col._uuid: 1 for col in final_select})
         return cls.compile_query(table, query)
 
+    @classmethod
+    def compile_ordered_aggregation(
+        cls, *args: sqa.ColumnElement, order_by: list[sqa.UnaryExpression], impl
+    ):
+        return impl(*args).within_group(*order_by)
+
 
 def convert_order_list(order_list: list[Order]) -> list[Order]:
     new_list: list[Order] = []

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -49,7 +49,7 @@ class MsSqlImpl(SqlImpl):
         *,
         schema_overrides: dict[UUID, Any],
     ) -> Any:
-        final_select = Cache.from_ast(nd).get_selected_cols()
+        final_select = Cache.from_ast(nd).selected_cols()
 
         for col in final_select:
             if types.without_const(col.dtype()) == Bool():
@@ -61,7 +61,7 @@ class MsSqlImpl(SqlImpl):
     @classmethod
     def build_select(cls, nd: AstNode, *, final_select: list[Col] | None = None) -> Any:
         if final_select is None:
-            final_select = Cache.from_ast(nd).get_selected_cols()
+            final_select = Cache.from_ast(nd).selected_cols()
 
         # boolean / bit conversion
         for desc in nd.iter_subtree_postorder():

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import functools
 from typing import Any
+from uuid import UUID
 
 import sqlalchemy as sqa
 from sqlalchemy.dialects.mssql import DATETIME2
@@ -46,18 +47,16 @@ class MsSqlImpl(SqlImpl):
         nd: AstNode,
         target: Target,
         *,
-        schema_overrides: dict[Col, Any],
+        schema_overrides: dict[UUID, Any],
     ) -> Any:
         final_select = Cache.from_ast(nd).get_selected_cols()
 
         for col in final_select:
             if types.without_const(col.dtype()) == Bool():
-                if col not in schema_overrides:
-                    schema_overrides[col] = col.dtype().to_polars()
+                if col._uuid not in schema_overrides:
+                    schema_overrides[col._uuid] = col.dtype().to_polars()
 
-        return super().export(
-            nd, target, final_select=final_select, schema_overrides=schema_overrides
-        )
+        return super().export(nd, target, schema_overrides=schema_overrides)
 
     @classmethod
     def build_select(cls, nd: AstNode, *, final_select: list[Col] | None = None) -> Any:

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -29,6 +29,8 @@ from pydiverse.transform._internal.tree.col_expr import (
 
 
 class MsSqlImpl(SqlImpl):
+    backend_name = "mssql"
+
     @classmethod
     def inf(cls):
         raise NotSupportedError("SQL Server does not support `inf`")

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -28,12 +28,16 @@ from pydiverse.transform._internal.tree.col_expr import (
 
 class MsSqlImpl(SqlImpl):
     @classmethod
-    def inf():
+    def inf(cls):
         raise NotSupportedError("SQL Server does not support `inf`")
 
     @classmethod
-    def nan():
+    def nan(cls):
         raise NotSupportedError("SQL Server does not support `nan`")
+
+    @classmethod
+    def default_collation(cls):
+        return "Latin1_General_bin"
 
     @classmethod
     def export(

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -89,8 +89,10 @@ class MsSqlImpl(SqlImpl):
                         node.context_kwargs["arrange"] = convert_order_list(arrange)
 
         sql.create_aliases(nd, {})
-        table, query, _ = cls.compile_ast(nd, {col._uuid: 1 for col in final_select})
-        return cls.compile_query(table, query)
+        table, query, sqa_expr = cls.compile_ast(
+            nd, {col._uuid: 1 for col in final_select}
+        )
+        return cls.compile_query(table, query, sqa_expr)
 
     @classmethod
     def compile_ordered_aggregation(

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -307,7 +307,8 @@ def compile_ast(
         )
 
     elif isinstance(nd, verbs.Filter):
-        df = df.filter([compile_col_expr(fil, name_in_df) for fil in nd.predicates])
+        if nd.predicates:
+            df = df.filter(compile_col_expr(fil, name_in_df) for fil in nd.predicates)
 
     elif isinstance(nd, verbs.Arrange):
         order_by, descending, nulls_last = zip(

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -54,10 +54,12 @@ class PolarsImpl(TableImpl):
     def export(
         nd: AstNode,
         target: Target,
-        schema_overrides: dict,
+        *,
+        schema_overrides: dict[UUID, Any],  # TODO: use this
     ) -> Any:
         lf, name_in_df, select, _ = compile_ast(nd)
         lf = lf.select(*(name_in_df[uid] for uid in select))
+
         if isinstance(target, Polars):
             if not target.lazy and isinstance(lf, pl.LazyFrame):
                 lf = lf.collect()

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -30,6 +30,8 @@ from pydiverse.transform._internal.tree.col_expr import (
 
 
 class PolarsImpl(TableImpl):
+    backend_name = "polars"
+
     def __init__(self, name: str, df: pl.DataFrame | pl.LazyFrame):
         self.df = df if isinstance(df, pl.LazyFrame) else df.lazy()
         self.df = self.df.cast(

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -446,13 +446,10 @@ def compile_ast(
                 )
 
         else:
-            if nd.how in ("left", "full"):
+            assert nd.how != "full"
+            if nd.how == "left":
                 df = df.with_columns(
-                    __LEFT_INDEX__=pl.int_range(0, pl.len(), dtype=pl.Int64)
-                )
-            if nd.how in ("full"):
-                right_df = right_df.with_columns(
-                    __RIGHT_INDEX__=pl.int_range(0, pl.len(), dtype=pl.Int64)
+                    __INDEX__=pl.int_range(0, pl.len(), dtype=pl.Int64)
                 )
 
             joined = df.join_where(
@@ -465,14 +462,8 @@ def compile_ast(
                 if isinstance(left_col, Col) and isinstance(right_col, Col)
             )
 
-            if nd.how in ("left", "full"):
-                joined = df.join(joined, on="__LEFT_INDEX__", how="left").drop(
-                    "__LEFT_INDEX__"
-                )
-            if nd.how in ("full"):
-                joined = joined.join(right_df, on="__RIGHT_INDEX__", how="right").drop(
-                    "__RIGHT_INDEX__"
-                )
+            if nd.how == "left":
+                joined = df.join(joined, on="__INDEX__", how="left").drop("__INDEX__")
 
             df = joined
 

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -47,14 +47,13 @@ class PolarsImpl(TableImpl):
         )
 
     @staticmethod
-    def build_query(nd: AstNode, final_select: list[Col]) -> None:
+    def build_query(nd: AstNode) -> None:
         return None
 
     @staticmethod
     def export(
         nd: AstNode,
         target: Target,
-        final_select: list[Col],
         schema_overrides: dict,
     ) -> Any:
         lf, name_in_df, select, _ = compile_ast(nd)

--- a/src/pydiverse/transform/_internal/backend/postgres.py
+++ b/src/pydiverse/transform/_internal/backend/postgres.py
@@ -114,3 +114,7 @@ with PostgresImpl.impl_store.impl_manager as impl:
     @impl(ops.is_not_nan)
     def _is_not_nan(x):
         return x != PostgresImpl.nan()
+
+    @impl(ops.dur_days)
+    def _dur_days(x):
+        sqa.func.extract("DAYS", x)

--- a/src/pydiverse/transform/_internal/backend/postgres.py
+++ b/src/pydiverse/transform/_internal/backend/postgres.py
@@ -38,7 +38,7 @@ class PostgresImpl(SqlImpl):
         return super().sqa_type(pdt_type)
 
     @classmethod
-    def past_over_clause(
+    def fix_fn_types(
         cls, fn: ColFn, val: sqa.ColumnElement, *args: sqa.ColumnElement
     ) -> sqa.ColumnElement:
         if isinstance(fn.op, ops.DatetimeExtract | ops.DateExtract):

--- a/src/pydiverse/transform/_internal/backend/postgres.py
+++ b/src/pydiverse/transform/_internal/backend/postgres.py
@@ -11,6 +11,8 @@ from pydiverse.transform._internal.tree.col_expr import Cast, ColFn
 
 
 class PostgresImpl(SqlImpl):
+    backend_name = "postgres"
+
     @classmethod
     def compile_cast(cls, cast: Cast, sqa_col: dict[str, sqa.Label]) -> Cast:
         compiled_val = cls.compile_col_expr(cast.val, sqa_col)

--- a/src/pydiverse/transform/_internal/backend/postgres.py
+++ b/src/pydiverse/transform/_internal/backend/postgres.py
@@ -114,7 +114,3 @@ with PostgresImpl.impl_store.impl_manager as impl:
     @impl(ops.is_not_nan)
     def _is_not_nan(x):
         return x != PostgresImpl.nan()
-
-    @impl(ops.list_agg)
-    def _list_agg(x):
-        return sqa.func.array_agg(x)

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -429,7 +429,7 @@ class SqlImpl(TableImpl):
 
             # rewire col refs to the subquery
             query = Query(
-                [
+                select=[
                     sqa.Label(lb.name, col)
                     for lb in orig_select
                     if (col := table.columns.get(lb.name)) is not None

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -150,7 +150,7 @@ class SqlImpl(TableImpl):
         if isinstance(target, Polars):
             with engine.connect() as conn:
                 df = pl.read_database(
-                    sel,
+                    sel.compile(engine, compile_kwargs={"literal_binds": True}),
                     connection=conn,
                     schema_overrides={
                         sql_col.name: schema_overrides[col]

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -375,7 +375,7 @@ class SqlImpl(TableImpl):
         if isinstance(nd, verbs.Mutate | verbs.Summarize):
             query.select = [lb for lb in query.select if lb.name not in set(nd.names)]
 
-        if isinstance(nd, verbs.Alias) and nd.subquery:
+        if isinstance(nd, verbs.SubqueryMarker):
             if needed_cols.keys().isdisjoint(sqa_col.keys()):
                 # We cannot select zero columns from a subquery. This happens when the
                 # user only 0-ary functions after the subquery, e.g. `count`.

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -521,8 +521,7 @@ class SqlImpl(TableImpl):
                     operator.and_, (compiled_on, *right_query.where)
                 )
             elif nd.how == "full":
-                if query.where or right_query.where:
-                    raise ValueError("invalid filter before full join")
+                assert not (query.where or right_query.where)
 
             table = table.join(
                 right_table,

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -924,3 +924,7 @@ with SqlImpl.impl_store.impl_manager as impl:
     @impl(ops.str_join)
     def _str_join(x, delim):
         return sqa.func.aggregate_strings(x, delim)
+
+    @impl(ops.list_agg)
+    def _list_agg(x):
+        return sqa.func.array_agg(x)

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -516,9 +516,6 @@ class SqlImpl(TableImpl):
             right_table, right_query, right_sqa_col = cls.compile_ast(
                 nd.right, needed_cols
             )
-            right_table, right_query, right_sqa_col = cls.check_for_subquery(
-                nd, right_table, right_sqa_col, right_query, needed_cols, child=nd.right
-            )
             sqa_col.update(
                 {
                     uid: sqa.label(lb.name + nd.suffix, lb)

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -451,18 +451,7 @@ class SqlImpl(TableImpl):
 
         elif isinstance(nd, verbs.Mutate):
             for name, val, uid in zip(nd.names, nd.values, nd.uuids, strict=True):
-                if types.is_const(val.dtype()):
-                    # TODO: this is incorrect (e.g. for a window functions of a constant
-                    # column, transform does not determine the data type of the result
-                    # to be constant, then left joins fail)
-                    const_table = sqa.select(
-                        sqa.label(name, cls.compile_col_expr(val, sqa_col))
-                    ).subquery()
-                    sqa_col[uid] = sqa.label(name, const_table.columns.get(name))
-                    table = table.join(const_table, onclause=sqa.literal(True))
-                else:
-                    sqa_col[uid] = sqa.label(name, cls.compile_col_expr(val, sqa_col))
-
+                sqa_col[uid] = sqa.label(name, cls.compile_col_expr(val, sqa_col))
                 query.select.append(sqa_col[uid])
 
         elif isinstance(nd, verbs.Filter):

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -12,7 +12,15 @@ from uuid import UUID
 import polars as pl
 import sqlalchemy as sqa
 
-from pydiverse.common import String
+from pydiverse.common import (
+    Dtype,
+    Float,
+    Float64,
+    Int,
+    Int64,
+    NullType,
+    String,
+)
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.backend.targets import Polars, SqlAlchemy, Target
 from pydiverse.transform._internal.ops import ops
@@ -28,14 +36,6 @@ from pydiverse.transform._internal.tree.col_expr import (
     ColFn,
     LiteralCol,
     Order,
-)
-from pydiverse.transform._internal.tree.types import (
-    Dtype,
-    Float,
-    Float64,
-    Int,
-    Int64,
-    NullType,
 )
 
 

--- a/src/pydiverse/transform/_internal/backend/sqlite.py
+++ b/src/pydiverse/transform/_internal/backend/sqlite.py
@@ -17,6 +17,8 @@ from pydiverse.transform._internal.util.warnings import warn_non_standard
 
 
 class SqliteImpl(SqlImpl):
+    backend_name = "sqlite"
+
     @classmethod
     def inf(cls):
         return sqa.type_coerce(sqa.literal("1e314"), sqa.Double)

--- a/src/pydiverse/transform/_internal/backend/sqlite.py
+++ b/src/pydiverse/transform/_internal/backend/sqlite.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import sqlalchemy as sqa
 
-from pydiverse.transform._internal.backend.sql import SqlImpl
-from pydiverse.transform._internal.errors import NotSupportedError
-from pydiverse.transform._internal.ops import ops
-from pydiverse.transform._internal.tree import types
-from pydiverse.transform._internal.tree.col_expr import Cast, ColFn
-from pydiverse.transform._internal.tree.types import (
+from pydiverse.common import (
     Date,
     Datetime,
     Decimal,
     String,
 )
+from pydiverse.transform._internal.backend.sql import SqlImpl
+from pydiverse.transform._internal.errors import NotSupportedError
+from pydiverse.transform._internal.ops import ops
+from pydiverse.transform._internal.tree import types
+from pydiverse.transform._internal.tree.col_expr import Cast, ColFn
 from pydiverse.transform._internal.util.warnings import warn_non_standard
 
 

--- a/src/pydiverse/transform/_internal/backend/sqlite.py
+++ b/src/pydiverse/transform/_internal/backend/sqlite.py
@@ -26,6 +26,10 @@ class SqliteImpl(SqlImpl):
         raise NotSupportedError("SQLite does not have `nan`, use `null` instead.")
 
     @classmethod
+    def default_collation(cls):
+        return "BINARY"
+
+    @classmethod
     def compile_cast(cls, cast: Cast, sqa_col: dict[str, sqa.Label]) -> sqa.Cast:
         compiled_val = cls.compile_col_expr(cast.val, sqa_col)
         val_type = types.without_const(cast.val.dtype())
@@ -55,7 +59,7 @@ class SqliteImpl(SqlImpl):
         return sqa.cast(compiled_val, cls.sqa_type(cast.target_type))
 
     @classmethod
-    def past_over_clause(
+    def fix_fn_types(
         cls, fn: ColFn, val: sqa.ColumnElement, *args: sqa.ColumnElement
     ) -> sqa.ColumnElement:
         if (

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
 
 class TableImpl(AstNode):
+    backend_name: str
     impl_store = ImplStore()
 
     def __init__(self, name: str, schema: dict[str, Dtype]):

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -115,14 +115,14 @@ class TableImpl(AstNode):
         yield self
 
     @classmethod
-    def build_query(cls, nd: AstNode, final_select: list[Col]) -> str | None: ...
+    def build_query(cls, nd: AstNode) -> str | None: ...
 
     @classmethod
     def export(
         cls,
         nd: AstNode,
         target: Target,
-        final_select: list[Col],
+        *,
         schema_overrides: dict[Col, Any],
     ) -> Any: ...
 

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -89,10 +89,15 @@ class TableImpl(AstNode):
                 res = DuckDbPolarsImpl(name, resource)
 
         elif isinstance(resource, str | sqa.Table):
-            if isinstance(backend, SqlAlchemy):
-                from pydiverse.transform._internal.backend.sql import SqlImpl
+            if not isinstance(backend, SqlAlchemy):
+                raise TypeError(
+                    "If `resource` is a string or a SQLAlchemy table, `backend` must "
+                    "have type `SqlALchemy` and contain an engine."
+                )
 
-                res = SqlImpl(resource, backend, name)
+            from pydiverse.transform._internal.backend.sql import SqlImpl
+
+            res = SqlImpl(resource, backend, name)
 
         else:
             raise AssertionError

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -123,7 +123,7 @@ class TableImpl(AstNode):
         nd: AstNode,
         target: Target,
         *,
-        schema_overrides: dict[Col, Any],
+        schema_overrides: dict[UUID, Any],
     ) -> Any: ...
 
     @classmethod

--- a/src/pydiverse/transform/_internal/backend/targets.py
+++ b/src/pydiverse/transform/_internal/backend/targets.py
@@ -25,3 +25,6 @@ class SqlAlchemy(Target):
     def __init__(self, engine: sqa.Engine, *, schema: str | None = None):
         self.engine = engine
         self.schema = schema
+
+
+class Scalar(Target): ...

--- a/src/pydiverse/transform/_internal/errors/__init__.py
+++ b/src/pydiverse/transform/_internal/errors/__init__.py
@@ -23,6 +23,12 @@ class SubqueryError(Exception):
     """
 
 
+class ColumnNotFoundError(Exception):
+    """
+    Raised if a column does not exist in the current table.
+    """
+
+
 class NonStandardWarning(UserWarning):
     """
     Category for when a specific backend deviates from

--- a/src/pydiverse/transform/_internal/ops/ops/aggregation.py
+++ b/src/pydiverse/transform/_internal/ops/ops/aggregation.py
@@ -6,10 +6,11 @@ from pydiverse.transform._internal.tree.types import (
     COMPARABLE,
     NUMERIC,
     Bool,
-    D,
+    Const,
     Decimal,
     Float,
     Int,
+    S,
     String,
 )
 
@@ -81,7 +82,7 @@ all = Aggregation(
 
 count = Aggregation(
     "count",
-    Signature(D, return_type=Int()),
+    Signature(S, return_type=Int()),
     doc="""
 Counts the number of non-null elements in the column.
 """,
@@ -98,7 +99,7 @@ Returns the number of rows of the current table, like :code:`COUNT(*)` in SQL.
 
 str_join = Aggregation(
     "str.join",
-    Signature(String(), String(const=True), return_type=String()),
+    Signature(String(), Const(String()), return_type=String()),
     param_names=["self", "delimiter"],
     default_values=[..., ""],
     context_kwargs=[

--- a/src/pydiverse/transform/_internal/ops/ops/aggregation.py
+++ b/src/pydiverse/transform/_internal/ops/ops/aggregation.py
@@ -65,6 +65,7 @@ mean = Aggregation(
 sum = Aggregation(
     "sum",
     *(Signature(dtype, return_type=dtype) for dtype in NUMERIC),
+    Signature(Bool(), return_type=Int()),
     doc="Computes the sum of values in each group.",
 )
 

--- a/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
+++ b/src/pydiverse/transform/_internal/ops/ops/arithmetic.py
@@ -4,6 +4,7 @@ from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
 from pydiverse.transform._internal.tree.types import (
     NUMERIC,
+    Bool,
     Date,
     Datetime,
     Decimal,
@@ -17,6 +18,7 @@ add = Operator(
     "__add__",
     *(Signature(dtype, dtype, return_type=dtype) for dtype in NUMERIC),
     Signature(String(), String(), return_type=String()),
+    Signature(Bool(), Bool(), return_type=Int()),
     Signature(Duration(), Duration(), return_type=Duration()),
     Signature(Datetime(), Duration(), return_type=Datetime()),
     Signature(Duration(), Datetime(), return_type=Datetime()),

--- a/src/pydiverse/transform/_internal/ops/ops/comparison.py
+++ b/src/pydiverse/transform/_internal/ops/ops/comparison.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import COMPARABLE, Bool, D
+from pydiverse.transform._internal.tree.types import COMPARABLE, Bool, S
 
 equal = Operator(
-    "__eq__", Signature(D, D, return_type=Bool()), doc="Equality comparison =="
+    "__eq__", Signature(S, S, return_type=Bool()), doc="Equality comparison =="
 )
 
 not_equal = Operator(
-    "__ne__", Signature(D, D, return_type=Bool()), doc="Non-equality comparison !="
+    "__ne__", Signature(S, S, return_type=Bool()), doc="Non-equality comparison !="
 )
 
 
@@ -39,25 +39,25 @@ greater_equal = Operator(
 
 is_null = Operator(
     "is_null",
-    Signature(D, return_type=Bool()),
+    Signature(S, return_type=Bool()),
     doc="Indicates whether the value is null.",
 )
 
 is_not_null = Operator(
     "is_not_null",
-    Signature(D, return_type=Bool()),
+    Signature(S, return_type=Bool()),
     doc="Indicates whether the value is not null.",
 )
 
 fill_null = Operator(
     "fill_null",
-    Signature(D, D, return_type=D),
+    Signature(S, S, return_type=S),
     doc="Replaces every null by the given value.",
 )
 
 is_in = Operator(
     "is_in",
-    Signature(D, D, ..., return_type=Bool()),
+    Signature(S, S, ..., return_type=Bool()),
     doc="""
 Whether the value equals one of the given.
 

--- a/src/pydiverse/transform/_internal/ops/ops/horizontal.py
+++ b/src/pydiverse/transform/_internal/ops/ops/horizontal.py
@@ -6,8 +6,8 @@ from pydiverse.transform._internal.tree.types import (
     COMPARABLE,
     NUMERIC,
     Bool,
-    D,
     Duration,
+    S,
     String,
 )
 
@@ -91,7 +91,7 @@ shape: (6, 4)
 
 coalesce = Horizontal(
     "coalesce",
-    Signature(D, D, ..., return_type=D),
+    Signature(S, S, ..., return_type=S),
     doc="""
 Returns the first non-null value among the given.
 

--- a/src/pydiverse/transform/_internal/ops/ops/list.py
+++ b/src/pydiverse/transform/_internal/ops/ops/list.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from pydiverse.transform._internal.ops.op import ContextKwarg
 from pydiverse.transform._internal.ops.ops.aggregation import Aggregation
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import D, List
+from pydiverse.transform._internal.tree.types import List, S
 
 list_agg = Aggregation(
     "list.agg",
-    Signature(D, return_type=List()),
+    Signature(S, return_type=List(S)),
     context_kwargs=[
         ContextKwarg("partition_by"),
         ContextKwarg("arrange"),

--- a/src/pydiverse/transform/_internal/ops/ops/markers.py
+++ b/src/pydiverse/transform/_internal/ops/ops/markers.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import D
+from pydiverse.transform._internal.tree.types import S
 
 
 class Marker(Operator):
     def __init__(self, name: str, doc: str = ""):
         super().__init__(
             name,
-            Signature(D, return_type=D),
+            Signature(S, return_type=S),
             doc=doc
             + """
 Can only be used in expressions given to the `arrange` verb or as as an

--- a/src/pydiverse/transform/_internal/ops/ops/numeric.py
+++ b/src/pydiverse/transform/_internal/ops/ops/numeric.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import NUMERIC, Bool, Decimal, Float, Int
+from pydiverse.transform._internal.tree.types import (
+    NUMERIC,
+    Bool,
+    Const,
+    Decimal,
+    Float,
+    Int,
+)
 
 pow = Operator(
     "__pow__",
@@ -39,7 +46,7 @@ abs = Operator(
 
 round = Operator(
     "round",
-    *(Signature(t, Int(const=True), return_type=t) for t in NUMERIC),
+    *(Signature(t, Const(Int()), return_type=t) for t in NUMERIC),
     param_names=["self", "decimals"],
     default_values=[..., 0],
     doc="""

--- a/src/pydiverse/transform/_internal/ops/ops/string.py
+++ b/src/pydiverse/transform/_internal/ops/ops/string.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from pydiverse.transform._internal.ops.op import Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import Bool, Date, Datetime, Int, String
+from pydiverse.transform._internal.tree.types import (
+    Bool,
+    Const,
+    Date,
+    Datetime,
+    Int,
+    String,
+)
 
 
 class StrUnary(Operator):
@@ -134,7 +141,7 @@ shape: (4, 4)
 
 str_replace_all = Operator(
     "str.replace_all",
-    Signature(String(), String(const=True), String(const=True), return_type=String()),
+    Signature(String(), Const(String()), Const(String()), return_type=String()),
     param_names=["self", "substr", "replacement"],
     doc="""
 Replaces all occurrences of a given substring by a different string.
@@ -181,7 +188,7 @@ shape: (5, 5)
 
 str_starts_with = Operator(
     "str.starts_with",
-    Signature(String(), String(const=True), return_type=Bool()),
+    Signature(String(), Const(String()), return_type=Bool()),
     param_names=["self", "prefix"],
     doc="""
 Whether the string starts with a given prefix.
@@ -224,7 +231,7 @@ shape: (5, 4)
 
 str_ends_with = Operator(
     "str.ends_with",
-    Signature(String(), String(const=True), return_type=Bool()),
+    Signature(String(), Const(String()), return_type=Bool()),
     param_names=["self", "suffix"],
     doc="""
 Whether the string ends with a given suffix.
@@ -269,7 +276,7 @@ shape: (5, 5)
 
 str_contains = Operator(
     "str.contains",
-    Signature(String(), String(const=True), return_type=Bool()),
+    Signature(String(), Const(String()), return_type=Bool()),
     param_names=["self", "substr"],
     doc="""
 Whether the string contains a given substring.

--- a/src/pydiverse/transform/_internal/ops/ops/window.py
+++ b/src/pydiverse/transform/_internal/ops/ops/window.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydiverse.transform._internal.ops.op import ContextKwarg, Ftype, Operator
 from pydiverse.transform._internal.ops.signature import Signature
-from pydiverse.transform._internal.tree.types import NUMERIC, D, Int, Tvar
+from pydiverse.transform._internal.tree.types import NUMERIC, Const, Int, S
 
 
 class Window(Operator):
@@ -35,7 +35,7 @@ class Window(Operator):
 
 shift = Window(
     "shift",
-    Signature(D, Int(const=True), Tvar("D", const=True), return_type=D),
+    Signature(S, Const(Int()), Const(S), return_type=S),
     param_names=["self", "n", "fill_value"],
     default_values=[..., ..., None],
     generate_expr_method=True,

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -56,15 +56,15 @@ class Cache:
                     name: node.uuid_map[uid] for name, uid in self.name_to_uuid.items()
                 }
                 res.uuid_to_name = {uid: name for name, uid in res.name_to_uuid.items()}
-                res.partition_by = [
-                    self.cols[node.uuid_map[col._uuid]] for col in self.partition_by
-                ]
                 res.cols = {
                     node.uuid_map[uid]: Col(
                         col.name, node, node.uuid_map[uid], col._dtype, col._ftype
                     )
                     for uid, col in self.cols.items()
                 }
+                res.partition_by = [
+                    res.cols[node.uuid_map[col._uuid]] for col in self.partition_by
+                ]
                 res.derived_from = set()
 
         elif isinstance(node, verbs.Select):

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import dataclasses
+from uuid import UUID
+
+from pydiverse.transform._internal.backend.table_impl import TableImpl
+from pydiverse.transform._internal.tree import verbs
+from pydiverse.transform._internal.tree.ast import AstNode
+from pydiverse.transform._internal.tree.col_expr import Col
+
+
+@dataclasses.dataclass(slots=True)
+class Cache:
+    name_to_uuid: dict[str, UUID]  # the selected columns, in order
+    uuid_to_name: dict[UUID, str]  # again, only the selected columns + in order
+    partition_by: list[Col]
+    derived_from: set[AstNode]  # for detecting invalid columns and self-joins
+    cols: dict[UUID, Col]  # all columns in current scope (including hidden ones)
+
+    # For a column to be usable in an expression, the table it comes from must be an
+    # ancestor of the current table AND the column's UUID must be in `all_cols` of the
+    # current table (the latter is necessary because not every column is usable after
+    # `summarize``)
+
+    @staticmethod
+    def from_ast(node: AstNode) -> Cache:
+        if isinstance(node, verbs.Verb):
+            if isinstance(node, verbs.Join):
+                return Cache.from_ast(node.child).update(
+                    node, right_cache=Cache.from_ast(node.right)
+                )
+            else:
+                Cache.from_ast(node.child).update(node)
+
+        assert isinstance(node, TableImpl)
+        return Cache(
+            {col.name: col._uuid for col in node.cols.values()},
+            {col._uuid: col.name for col in node.cols.values()},
+            [],
+            {node},
+            {col._uuid: col for col in node.cols.values()},
+        )
+
+    def update(self, node: verbs.Verb, *, right_cache: Cache | None = None):
+        if isinstance(node, verbs.Select):
+            selected_uuids = set(col._uuid for col in node.select)
+            self.uuid_to_name = {
+                uid: name
+                for uid, name in self.uuid_to_name.items()
+                if uid in selected_uuids
+            }
+            self.name_to_uuid = {name: uid for uid, name in self.uuid_to_name.items()}
+
+        elif isinstance(node, verbs.Rename):
+            self.name_to_uuid = {
+                (new_name if (new_name := node.name_map.get(name)) else name): uid
+                for name, uid in self.name_to_uuid.items()
+            }
+            self.uuid_to_name = {uid: name for name, uid in self.name_to_uuid.items()}
+
+        elif isinstance(node, verbs.Mutate):
+            self.cols = self.cols | {
+                uid: Col(name, node, uid, val.dtype(), val.ftype(agg_is_window=True))
+                for name, val, uid in zip(
+                    node.names, node.values, node.uuids, strict=True
+                )
+            }
+            self.name_to_uuid = self.name_to_uuid | {
+                name: uid for name, uid in zip(node.names, node.uuids, strict=True)
+            }
+            self.uuid_to_name = {uid: name for name, uid in self.name_to_uuid.items()}
+
+        elif isinstance(node, verbs.GroupBy):
+            if node.add:
+                self.partition_by = self.partition_by + node.group_by
+            else:
+                self.partition_by = node.group_by
+
+        elif isinstance(node, verbs.Ungroup):
+            self.partition_by = []
+
+        elif isinstance(node, verbs.Summarize):
+            overwritten = {
+                col_name for col_name in node.names if col_name in self.name_to_uuid
+            }
+            cols = {
+                self.uuid_to_name[col._uuid]: col
+                for col in self.partition_by
+                if self.uuid_to_name[col._uuid] not in overwritten
+            } | {
+                name: Col(name, node, uid, val.dtype(), val.ftype())
+                for name, val, uid in zip(
+                    node.names, node.values, node.uuids, strict=True
+                )
+            }
+
+            self.cols = {col._uuid: col for _, col in cols.items()}
+            self.name_to_uuid = {name: col._uuid for name, col in cols.items()}
+            self.uuid_to_name = {uid: name for name, uid in self.name_to_uuid.items()}
+            self.partition_by = []
+
+        elif isinstance(node, verbs.Join):
+            assert right_cache is not None
+
+            self.cols = self.cols | right_cache.cols
+            self.name_to_uuid = self.name_to_uuid | {
+                name + node.suffix: uid
+                for name, uid in right_cache.name_to_uuid.items()
+            }
+            self.uuid_to_name = self.uuid_to_name | {
+                uid: name + node.suffix
+                for uid, name in right_cache.uuid_to_name.items()
+            }
+            self.derived_from = self.derived_from | right_cache.derived_from
+
+        assert len(self.name_to_uuid) == len(self.uuid_to_name)
+
+        self.derived_from = self.derived_from | {node}
+
+    def get_selected_cols(self) -> list[Col]:
+        return [self.cols[uid] for uid in self.uuid_to_name.keys()]

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.ops.op import Ftype
-from pydiverse.transform._internal.tree import verbs
+from pydiverse.transform._internal.tree import types, verbs
 from pydiverse.transform._internal.tree.ast import AstNode
 from pydiverse.transform._internal.tree.col_expr import Col, ColFn
 
@@ -203,7 +203,16 @@ class Cache:
                     )
                 )
             )
-            or (isinstance(node, verbs.Join) and self.group_by)
+            or (
+                isinstance(node, verbs.Join)
+                and (
+                    self.group_by
+                    or any(
+                        types.is_const(self.cols[uid].dtype())
+                        for uid in self.uuid_to_name.keys()
+                    )
+                )
+            )
         )
 
     def selected_cols(self) -> list[Col]:

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -161,7 +161,7 @@ class Cache:
                     | verbs.GroupBy
                     | verbs.Join,
                 )
-                and self.limit is not None
+                and self.limit != 0
             )
             or (
                 isinstance(node, verbs.Mutate)

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -228,6 +228,10 @@ class Cache:
                         for col in node.iter_col_nodes()
                         if isinstance(col, Col)
                     )
+                    or any(
+                        self.cols[uid].ftype() == Ftype.WINDOW
+                        for uid in self.partition_by
+                    )
                 )
             )
             or (

--- a/src/pydiverse/transform/_internal/pipe/functions.py
+++ b/src/pydiverse/transform/_internal/pipe/functions.py
@@ -31,7 +31,10 @@ from pydiverse.transform._internal.tree.types import (
 
 def when(condition: ColExpr) -> WhenClause:
     condition = wrap_literal(condition)
-    if condition.dtype() is not None and not condition.dtype() <= Bool():
+    if (
+        condition.dtype() is not None
+        and not types.without_const(condition.dtype()) == Bool()
+    ):
         raise TypeError(
             "argument for `when` must be of boolean type, but has type "
             f"`{condition.dtype()}`"

--- a/src/pydiverse/transform/_internal/pipe/functions.py
+++ b/src/pydiverse/transform/_internal/pipe/functions.py
@@ -197,6 +197,10 @@ def max(arg: ColExpr[Datetime], *args: ColExpr[Datetime]) -> ColExpr[Datetime]: 
 def max(arg: ColExpr[Date], *args: ColExpr[Date]) -> ColExpr[Date]: ...
 
 
+@overload
+def max(arg: ColExpr[Bool], *args: ColExpr[Bool]) -> ColExpr[Bool]: ...
+
+
 def max(arg: ColExpr, *args: ColExpr) -> ColExpr:
     """
     The maximum of the given columns.
@@ -252,6 +256,10 @@ def min(arg: ColExpr[Datetime], *args: ColExpr[Datetime]) -> ColExpr[Datetime]: 
 
 @overload
 def min(arg: ColExpr[Date], *args: ColExpr[Date]) -> ColExpr[Date]: ...
+
+
+@overload
+def min(arg: ColExpr[Bool], *args: ColExpr[Bool]) -> ColExpr[Bool]: ...
 
 
 def min(arg: ColExpr, *args: ColExpr) -> ColExpr:

--- a/src/pydiverse/transform/_internal/pipe/pipeable.py
+++ b/src/pydiverse/transform/_internal/pipe/pipeable.py
@@ -70,8 +70,9 @@ def modify_ast(fn):
                         f"Executing the `{new._ast.__class__.__name__.lower()}` verb "
                         f"on the table `{ast_node.name}` requires a subquery, which "
                         "is forbidden in transform by default.\n"
-                        "hint: If you are sure you want to do a subquery, put an "
-                        f"`>> alias()` on `{ast_node.name}` before this verb."
+                        f"hint: Materialize the table `{ast_node.name}` before this "
+                        "verb. If you are sure you want to do a subquery, put an "
+                        "`>> alias()` before this verb. "
                     )
                 return True
             return False

--- a/src/pydiverse/transform/_internal/pipe/pipeable.py
+++ b/src/pydiverse/transform/_internal/pipe/pipeable.py
@@ -91,7 +91,7 @@ def modify_ast(fn):
         if isinstance(new._ast, verbs.Join) and _check_subquery(
             args[0]._cache, args[0]._ast
         ):
-            new._ast.child = verbs.SubqueryMarker(new._ast.child)
+            new._ast.right = verbs.SubqueryMarker(new._ast.right)
             # here limit and group_by are reset by Cache.update anyway
 
         return new

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import dataclasses
 import inspect
 from collections.abc import Callable, Iterable
@@ -17,14 +16,6 @@ from pydiverse.transform._internal.backend.targets import Target
 from pydiverse.transform._internal.pipe.pipeable import Pipeable
 from pydiverse.transform._internal.tree.ast import AstNode
 from pydiverse.transform._internal.tree.col_expr import Col, ColName
-from pydiverse.transform._internal.tree.verbs import (
-    Join,
-    Mutate,
-    Rename,
-    Select,
-    Summarize,
-    Verb,
-)
 
 
 class Table:
@@ -174,7 +165,6 @@ class Table:
 
         self._ast: AstNode = TableImpl.from_resource(resource, backend, name=name)
         self._cache = Cache(
-            list(self._ast.cols.values()),
             {col.name: col._uuid for col in self._ast.cols.values()},
             {col._uuid: col.name for col in self._ast.cols.values()},
             [],
@@ -194,7 +184,7 @@ class Table:
             raise ValueError(
                 f"column `{name}` does not exist in table `{self._ast.name}`"
             )
-        col = self._cache.all_cols[self._cache.name_to_uuid[name]]
+        col = self._cache.cols[self._cache.name_to_uuid[name]]
         return Col(name, self._ast, col._uuid, col._dtype, col._ftype)
 
     def __setstate__(self, d):  # to avoid very annoying AttributeErrors
@@ -202,14 +192,18 @@ class Table:
             setattr(self, slot, val)
 
     def __iter__(self) -> Iterable[Col]:
-        cols = copy.copy(self._cache.select)
+        cols = [self[col] for col in self._cache.name_to_uuid]
         yield from cols
 
     def __contains__(self, col: str | Col | ColName) -> bool:
-        return self._cache.has_col(col)
+        if isinstance(col, Col):
+            return col._uuid in self._cache.uuid_to_name
+        if isinstance(col, ColName):
+            col = col.name
+        return col in self._cache.name_to_uuid
 
     def __len__(self) -> int:
-        return len(self._cache.select)
+        return len(self._cache.name_to_uuid)
 
     def __rshift__(self, rhs) -> Table:
         """
@@ -253,11 +247,7 @@ class Table:
         return table_str
 
     def __dir__(self) -> list[str]:
-        return [
-            name
-            for name in self._cache.name_to_uuid.keys()
-            if self._cache.has_col(name)
-        ]
+        return [name for name in self._cache.name_to_uuid.keys()]
 
     def _repr_html_(self) -> str | None:
         html = (
@@ -283,111 +273,14 @@ class Table:
         p.text(str(self) if not cycle else "...")
 
 
+# For a column to be usable in an expression, the table it comes from must be an
+# ancestor of the current table AND the column's UUID must be in `all_cols` of the
+# current table (the latter is necessary because not every column is usable after
+# `summarize``)
 @dataclasses.dataclass(slots=True)
 class Cache:
-    # TODO: think about what sets of columns are in the respective structures and
-    # write this here.
-    select: list[Col]
-    name_to_uuid: dict[str, UUID]
-    uuid_to_name: dict[UUID, str]  # only the selected UUIDs
+    name_to_uuid: dict[str, UUID]  # the selected columns, in order
+    uuid_to_name: dict[UUID, str]  # again, only the selected columns + in order
     partition_by: list[Col]
-    # all nodes that this table is derived from (it cannot be joined with another node
-    # having nonempty intersection of `derived_from`)
-    derived_from: set[AstNode]
-    all_cols: dict[UUID, Col]  # all columns in current scope (including unnamed ones)
-
-    def has_col(self, col: str | Col | ColName) -> bool:
-        if isinstance(col, Col):
-            return col._uuid in self.uuid_to_name
-        if isinstance(col, ColName):
-            col = col.name
-        return col in self.name_to_uuid and self.name_to_uuid[col] in self.uuid_to_name
-
-    def update(self, vb: Verb, rcache: Cache | None = None):
-        if isinstance(vb, Select):
-            self.select = vb.select
-            selected_uuids = set(col._uuid for col in self.select)
-            selected_names = set(
-                name for uid, name in self.uuid_to_name.items() if uid in selected_uuids
-            )
-            self.uuid_to_name = {
-                uid: name
-                for uid, name in self.uuid_to_name.items()
-                if name in selected_names
-            }
-            self.name_to_uuid = {
-                name: uid
-                for name, uid in self.name_to_uuid.items()
-                if name in selected_names
-            }
-
-        elif isinstance(vb, Rename):
-            self.name_to_uuid = {
-                (new_name if (new_name := vb.name_map.get(name)) else name): uid
-                for name, uid in self.name_to_uuid.items()
-            }
-            self.uuid_to_name = self.uuid_to_name | {
-                uid: name for name, uid in self.name_to_uuid.items()
-            }
-
-        elif isinstance(vb, Mutate | Summarize):
-            if isinstance(vb, Mutate):
-                new_cols = {
-                    name: self.all_cols[uid] for name, uid in self.name_to_uuid.items()
-                }
-            else:
-                new_cols = {
-                    self.uuid_to_name[col._uuid]: col for col in self.partition_by
-                }
-            new_cols |= {
-                name: Col(
-                    name,
-                    vb,
-                    uid,
-                    val.dtype(),
-                    val.ftype(agg_is_window=isinstance(vb, Mutate)),
-                )
-                for name, val, uid in zip(vb.names, vb.values, vb.uuids, strict=True)
-            }
-
-            overwritten = {
-                col_name for col_name in vb.names if col_name in self.name_to_uuid
-            }
-
-            if isinstance(vb, Mutate):
-                self.select = [
-                    col
-                    for col in self.select
-                    if self.uuid_to_name[col._uuid] not in overwritten
-                ]
-            else:
-                self.select = self.partition_by
-            self.select = self.select + [new_cols[name] for name in vb.names]
-
-            self.all_cols = self.all_cols | {
-                col._uuid: col for _, col in new_cols.items()
-            }
-            self.name_to_uuid = {name: col._uuid for name, col in new_cols.items()}
-            self.uuid_to_name = {
-                uid: name
-                for uid, name in self.uuid_to_name.items()
-                if name not in overwritten
-            } | {uid: name for uid, name in zip(vb.uuids, vb.names, strict=False)}
-
-            if isinstance(vb, Summarize):
-                self.partition_by = []
-
-        elif isinstance(vb, Join):
-            self.select = self.select + rcache.select
-            self.all_cols = self.all_cols | rcache.all_cols
-            self.name_to_uuid = self.name_to_uuid | {
-                name + vb.suffix: uid for name, uid in rcache.name_to_uuid.items()
-            }
-
-            self.uuid_to_name = self.uuid_to_name | {
-                uid: name + vb.suffix for uid, name in rcache.uuid_to_name.items()
-            }
-
-            self.derived_from = self.derived_from | rcache.derived_from
-
-        self.derived_from = self.derived_from | {vb}
+    derived_from: set[AstNode]  # for detecting invalid columns and self-joins
+    cols: dict[UUID, Col]  # all columns in current scope (including hidden ones)

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -11,6 +11,7 @@ import sqlalchemy as sqa
 from pydiverse.transform._internal import errors
 from pydiverse.transform._internal.backend.table_impl import TableImpl
 from pydiverse.transform._internal.backend.targets import Target
+from pydiverse.transform._internal.errors import ColumnNotFoundError
 from pydiverse.transform._internal.pipe.cache import Cache
 from pydiverse.transform._internal.pipe.pipeable import Pipeable
 from pydiverse.transform._internal.tree.ast import AstNode
@@ -174,7 +175,7 @@ class Table:
             # for hasattr to work correctly on dunder methods
             raise AttributeError
         if name not in self._cache.name_to_uuid:
-            raise ValueError(
+            raise ColumnNotFoundError(
                 f"column `{name}` does not exist in table `{self._ast.name}`"
             )
         col = self._cache.cols[self._cache.name_to_uuid[name]]

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -185,7 +185,7 @@ class Table:
             setattr(self, slot, val)
 
     def __iter__(self) -> Iterable[Col]:
-        cols = self._cache.get_selected_cols()
+        cols = self._cache.selected_cols()
         yield from cols
 
     def __contains__(self, col: str | Col | ColName) -> bool:

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -183,11 +183,7 @@ class Table:
         )
 
     def __getitem__(self, key: str) -> Col:
-        if not isinstance(key, str):
-            raise TypeError(
-                f"argument to __getitem__ (bracket `[]` operator) on a Table must be a "
-                f"str, got {type(key)} instead."
-            )
+        errors.check_arg_type(str, "Table.__getitem__", "key", key)
         return self.__getattr__(key)
 
     def __getattr__(self, name: str) -> Col:

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable, Iterable
 from html import escape
+from typing import Literal
 
 import pandas as pd
 import polars as pl
@@ -265,3 +266,11 @@ class Table:
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self) if not cycle else "...")
+
+
+def backend(table: Table) -> Literal["polars", "sqlite", "postgres", "duckdb", "mssql"]:
+    return table._cache.backend
+
+
+def is_sql_backed(table: Table) -> bool:
+    return table._cache.backend != "polars"

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -1183,6 +1183,14 @@ def full_join(
     return left >> join(right, on, "full", validate=validate, suffix=suffix)
 
 
+@overload
+def cross_join(
+    right: Table,
+    *,
+    suffix: str | None = None,
+) -> Pipeable: ...
+
+
 @verb
 def cross_join(
     left: Table,
@@ -1191,10 +1199,10 @@ def cross_join(
     suffix: str | None = None,
 ) -> Pipeable:
     """
-    Alias for the :doc:`pydiverse.transform.join` verb with ``how="full"``.
+    Alias for the :doc:`pydiverse.transform.join` verb with an empty ``on`` clause.
     """
 
-    return left >> full_join(right, on=[], suffix=suffix)
+    return left >> join(right, how="inner", on=[], suffix=suffix)
 
 
 @overload

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -124,7 +124,7 @@ def alias(
     new = copy.copy(table)
     new._ast = Alias(
         new._ast,
-        {uid: uuid.uuid1() for uid in table._cache.cols.keys()}
+        uuid_map={uid: uuid.uuid1() for uid in table._cache.cols.keys()}
         if not keep_col_refs
         else None,
     )

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -1011,6 +1011,9 @@ def join(
         ["1:1", "1:m", "m:1", "m:m"], "join", "validate", validate
     )
 
+    if left._cache.backend != right._cache.backend:
+        raise TypeError("cannot join two tables with different backends")
+
     if left._cache.partition_by:
         raise ValueError(f"cannot join grouped table `{left._ast.name}`")
     elif right._cache.partition_by:

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -482,8 +482,6 @@ def rename(table: Table, name_map: dict[str, str]) -> Pipeable:
     └─────┴───────┴─────┴───────┘
     """
     errors.check_arg_type(dict, "rename", "name_map", name_map)
-    if len(name_map) == 0:
-        return table
 
     if d := set(name_map).difference(table._cache.name_to_uuid):
         raise ValueError(

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -536,6 +536,10 @@ def mutate(table: Table, **kwargs: ColExpr) -> Pipeable:
         uuids,
     )
 
+    # make sure the ftypes are written in there
+    for val in new._ast.values:
+        val.ftype(agg_is_window=True)
+
     new._cache = copy.copy(table._cache)
     new._cache.update(new._ast)
 

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -13,6 +13,7 @@ from pydiverse.transform._internal.errors import FunctionTypeError
 from pydiverse.transform._internal.ops.op import Ftype
 from pydiverse.transform._internal.pipe.pipeable import Pipeable, verb
 from pydiverse.transform._internal.pipe.table import Table
+from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.col_expr import (
     Col,
     ColExpr,
@@ -575,7 +576,7 @@ def filter(table: Table, *predicates: ColExpr[Bool]) -> Pipeable:
     new._ast = Filter(table._ast, [preprocess_arg(pred, table) for pred in predicates])
 
     for cond in new._ast.predicates:
-        if not cond.dtype() <= Bool():
+        if not types.without_const(cond.dtype()) == Bool():
             raise TypeError(
                 "predicates given to `filter` must be of boolean type.\n"
                 f"hint: {cond} is of type {cond.dtype()} instead."

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -928,7 +928,6 @@ def join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce=False,
 ) -> Pipeable: ...
 
 
@@ -941,7 +940,6 @@ def join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce=False,
 ) -> Pipeable:
     """
     Joins two tables on a boolean expression.
@@ -974,12 +972,6 @@ def join(
         appended to all columns of the right table. If this still does not resolve all
         name collisions, additionally an integer is appended to the column names of the
         right table.
-
-    :param coalesce:
-        If `on` is a list of strings and `coalesce=True`, the join columns are merged.
-        If there are no column name collisions apart from the join columns, no suffix is
-        appended to columns of the right table.
-
 
     Note
     ----
@@ -1029,18 +1021,11 @@ def join(
     errors.check_literal_type(
         ["1:1", "1:m", "m:1", "m:m"], "join", "validate", validate
     )
-    errors.check_arg_type(bool, "join", "coalesce", coalesce)
 
     if isinstance(on, str):
         on = [on]
     ignore_right = set()
     if isinstance(on, list):
-        if not all(type(cond) is str for cond in on) and coalesce:
-            raise ValueError(
-                "`coalesce` can only be set to True if `on` is a list of strings"
-            )
-        elif coalesce:
-            ignore_right = set(on)
         on = functools.reduce(
             operator.and_,
             (
@@ -1094,7 +1079,7 @@ def join(
         suffix = ""
 
     new = copy.copy(left)
-    new._ast = Join(left._ast, right._ast, on, how, validate, suffix, coalesce)
+    new._ast = Join(left._ast, right._ast, on, how, validate, suffix)
     # The join condition must be preprocessed with respect to both tables
     new._ast.on = resolve_C_columns(
         resolve_C_columns(new._ast.on, left, strict=False), right, suffix=suffix
@@ -1123,7 +1108,6 @@ def inner_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable: ...
 
 
@@ -1135,15 +1119,12 @@ def inner_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable:
     """
     Alias for the :doc:`pydiverse.transform.join` verb with ``how="inner"``.
     """
 
-    return left >> join(
-        right, on, "inner", validate=validate, suffix=suffix, coalesce=coalesce
-    )
+    return left >> join(right, on, "inner", validate=validate, suffix=suffix)
 
 
 @overload
@@ -1153,7 +1134,6 @@ def left_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable: ...
 
 
@@ -1165,15 +1145,12 @@ def left_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable:
     """
     Alias for the :doc:`pydiverse.transform.join` verb with ``how="left"``.
     """
 
-    return left >> join(
-        right, on, "left", validate=validate, suffix=suffix, coalesce=coalesce
-    )
+    return left >> join(right, on, "left", validate=validate, suffix=suffix)
 
 
 @overload
@@ -1183,7 +1160,6 @@ def full_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable: ...
 
 
@@ -1195,15 +1171,12 @@ def full_join(
     *,
     validate: Literal["1:1", "1:m", "m:1", "m:m"] = "m:m",
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable:
     """
     Alias for the :doc:`pydiverse.transform.join` verb with ``how="full"``.
     """
 
-    return left >> join(
-        right, on, "full", validate=validate, suffix=suffix, coalesce=coalesce
-    )
+    return left >> join(right, on, "full", validate=validate, suffix=suffix)
 
 
 @verb
@@ -1212,13 +1185,12 @@ def cross_join(
     right: Table,
     *,
     suffix: str | None = None,
-    coalesce: bool = False,
 ) -> Pipeable:
     """
     Alias for the :doc:`pydiverse.transform.join` verb with ``how="full"``.
     """
 
-    return left >> full_join(right, on=[], suffix=suffix, coalesce=coalesce)
+    return left >> full_join(right, on=[], suffix=suffix)
 
 
 @overload

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -35,7 +35,11 @@ from pydiverse.transform._internal.ops.op import Ftype, Operator
 from pydiverse.transform._internal.ops.ops.markers import Marker
 from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.ast import AstNode
-from pydiverse.transform._internal.tree.types import FLOAT_SUBTYPES, INT_SUBTYPES, Const
+from pydiverse.transform._internal.tree.types import (
+    FLOAT_SUBTYPES,
+    INT_SUBTYPES,
+    Const,
+)
 
 T = TypeVar("T")
 
@@ -311,6 +315,9 @@ class ColExpr(Generic[T]):
     def __add__(self: ColExpr[String], rhs: ColExpr[String]) -> ColExpr[String]: ...
 
     @overload
+    def __add__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Int]: ...
+
+    @overload
     def __add__(
         self: ColExpr[Duration], rhs: ColExpr[Duration]
     ) -> ColExpr[Duration]: ...
@@ -341,6 +348,9 @@ class ColExpr(Generic[T]):
 
     @overload
     def __radd__(self: ColExpr[String], rhs: ColExpr[String]) -> ColExpr[String]: ...
+
+    @overload
+    def __radd__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Int]: ...
 
     @overload
     def __radd__(
@@ -771,6 +781,9 @@ class ColExpr(Generic[T]):
     @overload
     def __ge__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Bool]: ...
 
+    @overload
+    def __ge__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Bool]: ...
+
     def __ge__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Greater than or equal to comparison >="""
 
@@ -793,6 +806,9 @@ class ColExpr(Generic[T]):
 
     @overload
     def __gt__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Bool]: ...
+
+    @overload
+    def __gt__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Bool]: ...
 
     def __gt__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Greater than comparison >"""
@@ -868,6 +884,9 @@ class ColExpr(Generic[T]):
     @overload
     def __le__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Bool]: ...
 
+    @overload
+    def __le__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Bool]: ...
+
     def __le__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Less than or equal to comparison <="""
 
@@ -890,6 +909,9 @@ class ColExpr(Generic[T]):
 
     @overload
     def __lt__(self: ColExpr[Date], rhs: ColExpr[Date]) -> ColExpr[Bool]: ...
+
+    @overload
+    def __lt__(self: ColExpr[Bool], rhs: ColExpr[Bool]) -> ColExpr[Bool]: ...
 
     def __lt__(self: ColExpr, rhs: ColExpr) -> ColExpr:
         """Less than comparison <"""
@@ -948,6 +970,14 @@ class ColExpr(Generic[T]):
         partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Date]: ...
+
+    @overload
+    def max(
+        self: ColExpr[Bool],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
+    ) -> ColExpr[Bool]: ...
 
     def max(
         self: ColExpr,
@@ -1040,6 +1070,14 @@ class ColExpr(Generic[T]):
         partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Date]: ...
+
+    @overload
+    def min(
+        self: ColExpr[Bool],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
+    ) -> ColExpr[Bool]: ...
 
     def min(
         self: ColExpr,
@@ -1445,6 +1483,14 @@ class ColExpr(Generic[T]):
         partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
         filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
     ) -> ColExpr[Decimal]: ...
+
+    @overload
+    def sum(
+        self: ColExpr[Bool],
+        *,
+        partition_by: Col | ColName | str | Iterable[Col | ColName | str] | None = None,
+        filter: ColExpr[Bool] | Iterable[ColExpr[Bool]] | None = None,
+    ) -> ColExpr[Int]: ...
 
     def sum(
         self: ColExpr,
@@ -2469,6 +2515,7 @@ class Cast(ColExpr):
                         ),
                     )
                 ),
+                *((Bool(), t) for t in itertools.chain(FLOAT_SUBTYPES, INT_SUBTYPES)),
             }
 
             if (
@@ -2553,6 +2600,9 @@ class Order:
 
     def dtype(self) -> Dtype:
         return self.order_by.dtype()
+
+    def ftype(self, *, agg_is_window: bool | None = None) -> Ftype:
+        return self.order_by.ftype(agg_is_window=agg_is_window)
 
     def iter_subtree(self) -> Iterable[ColExpr]:
         yield from self.order_by.iter_subtree()

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -33,7 +33,6 @@ from pydiverse.transform._internal.errors import FunctionTypeError
 from pydiverse.transform._internal.ops import ops
 from pydiverse.transform._internal.ops.op import Ftype, Operator
 from pydiverse.transform._internal.ops.ops.markers import Marker
-from pydiverse.transform._internal.pipe.pipeable import Pipeable
 from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.ast import AstNode
 from pydiverse.transform._internal.tree.types import FLOAT_SUBTYPES, INT_SUBTYPES, Const
@@ -255,11 +254,14 @@ class ColExpr(Generic[T]):
         return g(self)
 
     def __rshift__(self, rhs):
+        from pydiverse.transform._internal.pipe.pipeable import Pipeable
+
         if not isinstance(rhs, Pipeable):
             raise TypeError(
                 "the right shift operator `>>` can only be applied to a column "
                 "expression if a verb is on the right"
             )
+
         return rhs(self)
 
     def rank(

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2511,6 +2511,12 @@ class Order:
     # translated normally.
     @staticmethod
     def from_col_expr(expr: ColExpr) -> Order:
+        if not isinstance(expr, ColExpr):
+            raise TypeError(
+                f"argument to `arrange` must be a `ColExpr`, found `{type(expr)}` "
+                "instead.\n"
+                "hint: maybe you forgot to close parentheses `()`?"
+            )
         descending = None
         nulls_last = None
         while isinstance(expr, ColFn):

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2042,16 +2042,11 @@ class Col(ColExpr):
 
     def __str__(self) -> str:
         try:
-            from pydiverse.transform._internal.backend.polars import PolarsImpl
-            from pydiverse.transform._internal.backend.targets import Polars
-
-            df = PolarsImpl.export(self._ast, Polars(lazy=False), [self], {})
-            return str(df.get_column(df.columns[0]))
+            return str(self.export(Polars(lazy=False)))
         except Exception as e:
             return (
-                repr(self)
-                + f"\ncould not evaluate {repr(self)} due to"
-                + f"{e.__class__.__name__}: {str(e)}"
+                f"could not evaluate {repr(self)} due to "
+                f"{e.__class__.__name__}: {str(e)}"
             )
 
     def __hash__(self) -> int:
@@ -2096,7 +2091,7 @@ class Col(ColExpr):
         from pydiverse.transform._internal.tree.verbs import Select
 
         ast = Select(self._ast, [self])
-        df = get_backend(self._ast).export(ast, target, [self], {})
+        df = get_backend(self._ast).export(ast, target, schema_overrides={})
         if isinstance(target, Polars):
             if isinstance(df, pl.LazyFrame):
                 df = df.collect()

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2368,7 +2368,8 @@ class CaseExpr(ColExpr):
         ):
             val_ftypes.add(self.default_val.ftype(agg_is_window=agg_is_window))
 
-        for _, val in self.cases:
+        for cond, val in self.cases:
+            cond.ftype(agg_is_window=agg_is_window)
             if val.dtype() is not None and not types.is_const(val.dtype()):
                 val_ftypes.add(val.ftype(agg_is_window=agg_is_window))
 

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -85,6 +85,19 @@ class ColExpr(Generic[T]):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self) if not cycle else "...")
 
+    def iter_children(self) -> Iterable[ColExpr]:
+        return iter(())
+
+    # yields all ColExpr`s appearing in the subtree of `self`. Python builtin types
+    # and `Order` expressions are not yielded.
+    def iter_subtree(self) -> Iterable[ColExpr]:
+        for node in self.iter_children():
+            yield from node.iter_subtree()
+        yield self
+
+    def map_subtree(self, g: Callable[[ColExpr], ColExpr]) -> ColExpr:
+        return g(self)
+
     def dtype(self) -> Dtype:
         """
         Returns the data type of the expression.
@@ -239,19 +252,6 @@ class ColExpr(Generic[T]):
                 "instance or subclass of pdt.Dtype"
             )
         return Cast(self, target_type)
-
-    def iter_children(self) -> Iterable[ColExpr]:
-        return iter(())
-
-    # yields all ColExpr`s appearing in the subtree of `self`. Python builtin types
-    # and `Order` expressions are not yielded.
-    def iter_subtree(self) -> Iterable[ColExpr]:
-        for node in self.iter_children():
-            yield from node.iter_subtree()
-        yield self
-
-    def map_subtree(self, g: Callable[[ColExpr], ColExpr]) -> ColExpr:
-        return g(self)
 
     def __rshift__(self, rhs):
         from pydiverse.transform._internal.pipe.pipeable import Pipeable

--- a/src/pydiverse/transform/_internal/tree/types.py
+++ b/src/pydiverse/transform/_internal/tree/types.py
@@ -288,4 +288,5 @@ COMPARABLE = (
     String(),
     Datetime(),
     Date(),
+    Bool(),
 )

--- a/src/pydiverse/transform/_internal/tree/types.py
+++ b/src/pydiverse/transform/_internal/tree/types.py
@@ -1,134 +1,56 @@
 from __future__ import annotations
 
-import datetime
-import inspect
+import pydiverse.common as pdc
+from pydiverse.transform._internal import errors
 
 
-class Dtype:
+class Const(pdc.Dtype):
+    __slots__ = ("base",)
+
+    def __init__(self, base: pdc.Dtype):
+        self.base = base
+
+    def __repr__(self):
+        return "const " + repr(self.base)
+
+
+def without_const(dtype: pdc.Dtype):
     """
-    Base class for all data types.
+    Removes a `const` modifier from the data type (if present).
     """
-
-    __slots__ = ("const",)
-
-    def __init__(self, *, const: bool = False):
-        self.const = const
-
-    def __eq__(self, rhs: Dtype | type[Dtype] | None) -> bool:
-        if rhs is None:
-            return False
-        if inspect.isclass(rhs) and issubclass(rhs, Dtype):
-            rhs = rhs()
-
-        if isinstance(rhs, Dtype):
-            return self.const == rhs.const and type(self) is type(rhs)
-        elif inspect.isclass(rhs) and issubclass(rhs, Dtype):
-            return not self.const and type(self) is rhs
-        raise TypeError(f"cannot compare type `Dtype` with type `{type(rhs)}`")
-
-    def __le__(self, rhs: Dtype):
-        if rhs.const and not self.const:
-            return False
-        return isinstance(self, type(rhs))
-
-    def __ne__(self, rhs: object) -> bool:
-        return not self.__eq__(rhs)
-
-    def __hash__(self):
-        return hash((type(self), self.const))
-
-    def __repr__(self) -> str:
-        return ("const " if self.const else "") + self.__class__.__name__
-
-    def with_const(self) -> Dtype:
-        """
-        Adds a `const` modifier from the data type.
-        """
-        return type(self)(const=True)
-
-    def without_const(self) -> Dtype:
-        """
-        Removes a `const` modifier from the data type (if present).
-        """
-        return type(self)()
-
-    def converts_to(self, target: Dtype) -> bool:
-        return (
-            not target.const or self.const
-        ) and target.without_const() in IMPLICIT_CONVS[self.without_const()]
+    errors.check_arg_type(pdc.Dtype, "without_const", "dtype", dtype)
+    if isinstance(dtype, Const):
+        return dtype.base
+    return dtype
 
 
-class Float(Dtype): ...
+def with_const(dtype: pdc.Dtype) -> pdc.Dtype:
+    """
+    Adds a `const` modifier from the data type.
+    """
+    errors.check_arg_type(pdc.Dtype, "with_const", "dtype", dtype)
+    if isinstance(dtype, Const):
+        return dtype
+    return Const(dtype)
 
 
-class Float64(Float): ...
+def converts_to(self, target: pdc.Dtype) -> bool:
+    return (
+        not target.const or self.const
+    ) and target.without_const() in IMPLICIT_CONVS[self.without_const()]
 
 
-class Float32(Float): ...
-
-
-class Decimal(Dtype): ...
-
-
-class Int(Dtype): ...
-
-
-class Int64(Int): ...
-
-
-class Int32(Int): ...
-
-
-class Int16(Int): ...
-
-
-class Int8(Int): ...
-
-
-class Uint64(Int): ...
-
-
-class Uint32(Int): ...
-
-
-class Uint16(Int): ...
-
-
-class Uint8(Int): ...
-
-
-class String(Dtype): ...
-
-
-class Bool(Dtype): ...
-
-
-class Datetime(Dtype): ...
-
-
-class Date(Dtype): ...
-
-
-class Duration(Dtype): ...
-
-
-class List(Dtype): ...
-
-
-class NullType(Dtype): ...
-
-
-class Tvar(Dtype):
+class Tvar(pdc.Dtype):
     __slots__ = ("name",)
 
     def __init__(self, name: str, *, const: bool = False):
         self.name = name
         super().__init__(const=const)
 
-    def __eq__(self, rhs: Dtype) -> bool:
+    def __eq__(self, rhs: pdc.Dtype) -> bool:
         if rhs is None:
             return False
-        if not isinstance(rhs, Dtype):
+        if not isinstance(rhs, pdc.Dtype):
             raise TypeError(f"cannot compare type `Dtype` with type `{type(rhs)}`")
         return (
             self.const == rhs.const and isinstance(rhs, Tvar) and rhs.name == self.name
@@ -137,74 +59,74 @@ class Tvar(Dtype):
     def __hash__(self):
         return hash((Tvar, self.const, self.name))
 
-    def with_const(self) -> Dtype:
+    def with_const(self) -> pdc.Dtype:
         return Tvar(self.name, const=True)
 
-    def without_const(self) -> Dtype:
+    def without_const(self) -> pdc.Dtype:
         return Tvar(self.name)
 
 
 D = Tvar("T")
 
 
-def python_type_to_pdt(t: type) -> Dtype:
-    if t is int:
-        return Int64()
-    elif t is float:
-        return Float64()
-    elif t is bool:
-        return Bool()
-    elif t is str:
-        return String()
-    elif t is datetime.datetime:
-        return Datetime()
-    elif t is datetime.date:
-        return Date()
-    elif t is datetime.timedelta:
-        return Duration()
-    elif t is list:
-        return List()
-    elif t is type(None):
-        return NullType()
+# def python_type_to_pdt(t: type) -> Dtype:
+#     if t is int:
+#         return Int64()
+#     elif t is float:
+#         return Float64()
+#     elif t is bool:
+#         return Bool()
+#     elif t is str:
+#         return String()
+#     elif t is datetime.datetime:
+#         return Datetime()
+#     elif t is datetime.date:
+#         return Date()
+#     elif t is datetime.timedelta:
+#         return Duration()
+#     elif t is list:
+#         return List()
+#     elif t is type(None):
+#         return NullType()
 
-    raise TypeError(
-        "objects used in a column expression must have type `ColExpr` or "
-        f"a suitable python builtin type, found `{t.__name__}` instead"
-    )
-
-
-def pdt_type_to_python(t: Dtype) -> type:
-    if t <= Int():
-        return int
-    elif t <= Float():
-        return float
-    elif t <= Bool():
-        return bool
-    elif t <= String():
-        return str
-    elif t <= Datetime():
-        return datetime.datetime
-    elif t <= Date():
-        return datetime.date
-    elif t <= Duration():
-        return datetime.timedelta
-    elif t <= List():
-        return list
-    elif t <= NullType():
-        return type(None)
-
-    raise AssertionError
+#     raise TypeError(
+#         "objects used in a column expression must have type `ColExpr` or "
+#         f"a suitable python builtin type, found `{t.__name__}` instead"
+#     )
 
 
-def promote_dtypes(dtypes: list[Dtype]) -> Dtype:
+# def pdt_type_to_python(t: Dtype) -> type:
+#     if t <= Int():
+#         return int
+#     elif t <= Float():
+#         return float
+#     elif t <= Bool():
+#         return bool
+#     elif t <= String():
+#         return str
+#     elif t <= Datetime():
+#         return datetime.datetime
+#     elif t <= Date():
+#         return datetime.date
+#     elif t <= Duration():
+#         return datetime.timedelta
+#     elif t <= List():
+#         return list
+#     elif t <= NullType():
+#         return type(None)
+
+#     raise AssertionError
+
+
+def promote_dtypes(dtypes: list[pdc.Dtype]) -> pdc.Dtype:
     if len(dtypes) == 0:
         raise ValueError("expected non empty list of dtypes")
 
     promoted = dtypes[0]
     for dtype in dtypes[1:]:
-        if isinstance(dtype, NullType):
+        if isinstance(dtype, pdc.NullType):
             continue
-        if isinstance(promoted, NullType):
+        if isinstance(promoted, pdc.NullType):
             promoted = dtype
             continue
 
@@ -220,62 +142,61 @@ def promote_dtypes(dtypes: list[Dtype]) -> Dtype:
 
 
 INT_SUBTYPES = (
-    Uint8(),
-    Uint16(),
-    Uint32(),
-    Uint64(),
-    Int8(),
-    Int16(),
-    Int32(),
-    Int64(),
+    pdc.Uint8(),
+    pdc.Uint16(),
+    pdc.Uint32(),
+    pdc.Uint64(),
+    pdc.Int8(),
+    pdc.Int16(),
+    pdc.Int32(),
+    pdc.Int64(),
 )
-FLOAT_SUBTYPES = (Float32(), Float64())
-ALL_TYPES = (
+FLOAT_SUBTYPES = (pdc.Float32(), pdc.Float64())
+SIMPLE_TYPES = (
     *INT_SUBTYPES,
     *FLOAT_SUBTYPES,
-    Int(),
-    Float(),
-    Decimal(),
-    String(),
-    Date(),
-    Datetime(),
-    Bool(),
-    NullType(),
-    Duration(),
-    List(),
+    pdc.Int(),
+    pdc.Float(),
+    pdc.Decimal(),
+    pdc.String(),
+    pdc.Date(),
+    pdc.Datetime(),
+    pdc.Bool(),
+    pdc.NullType(),
+    pdc.Duration(),
 )
 
 
-def is_supertype(dtype: Dtype) -> bool:
+def is_supertype(dtype: pdc.Dtype) -> bool:
     return not any(isinstance(dtype, type(t)) for t in (*INT_SUBTYPES, *FLOAT_SUBTYPES))
 
 
-def is_subtype(dtype: Dtype) -> bool:
-    return type(dtype) is not Int and type(dtype) is not Float
+def is_subtype(dtype: pdc.Dtype) -> bool:
+    return type(dtype) is not pdc.Int and type(dtype) is not pdc.Float
 
 
-IMPLICIT_CONVS: dict[Dtype, dict[Dtype, tuple[int, int]]] = {
-    Int(): {Float(): (1, 0), Decimal(): (2, 0), Int(): (0, 0)},
+IMPLICIT_CONVS: dict[pdc.Dtype, dict[pdc.Dtype, tuple[int, int]]] = {
+    pdc.Int(): {pdc.Float(): (1, 0), pdc.Decimal(): (2, 0), pdc.Int(): (0, 0)},
     **{
-        int_subtype: {Int(): (0, 1), int_subtype: (0, 0)}
+        int_subtype: {pdc.Int(): (0, 1), int_subtype: (0, 0)}
         for int_subtype in INT_SUBTYPES
     },
     **{
-        float_subtype: {Float(): (0, 1), float_subtype: (0, 0)}
+        float_subtype: {pdc.Float(): (0, 1), float_subtype: (0, 0)}
         for float_subtype in FLOAT_SUBTYPES
     },
-    Float(): {Float(): (0, 0)},
-    String(): {String(): (0, 0)},
-    Decimal(): {Decimal(): (0, 0)},
-    Datetime(): {Datetime(): (0, 0)},
-    Date(): {Date(): (0, 0)},
-    Bool(): {Bool(): (0, 0)},
-    NullType(): {
-        NullType(): (0, 0),
-        **{t: (1, 0) for t in ALL_TYPES if t != NullType()},
+    pdc.Float(): {pdc.Float(): (0, 0)},
+    pdc.String(): {pdc.String(): (0, 0)},
+    pdc.Decimal(): {pdc.Decimal(): (0, 0)},
+    pdc.Datetime(): {pdc.Datetime(): (0, 0)},
+    pdc.Date(): {pdc.Date(): (0, 0)},
+    pdc.Bool(): {pdc.Bool(): (0, 0)},
+    pdc.NullType(): {
+        pdc.NullType(): (0, 0),
+        **{t: (1, 0) for t in SIMPLE_TYPES if t != NullType()},
     },
-    Duration(): {Duration(): (0, 0)},
-    List(): {List(): (0, 0)},
+    pdc.Duration(): {pdc.Duration(): (0, 0)},
+    **{List(t): {List(t): (0, 0)} for t in SIMPLE_TYPES},
 }
 
 # compute transitive closure of cost graph
@@ -292,9 +213,16 @@ for start_type in (*INT_SUBTYPES, *FLOAT_SUBTYPES):
     IMPLICIT_CONVS[start_type] |= added_edges
 
 
-def conversion_cost(dtype: Dtype, target: Dtype) -> tuple[int, int]:
+def conversion_cost(dtype: pdc.Dtype, target: pdc.Dtype) -> tuple[int, int]:
     return IMPLICIT_CONVS[dtype.without_const()][target.without_const()]
 
 
-NUMERIC = (Int(), Float(), Decimal())
-COMPARABLE = (Int(), Float(), Decimal(), String(), Datetime(), Date())
+NUMERIC = (pdc.Int(), pdc.Float(), pdc.Decimal())
+COMPARABLE = (
+    pdc.Int(),
+    pdc.Float(),
+    pdc.Decimal(),
+    pdc.String(),
+    pdc.Datetime(),
+    pdc.Date(),
+)

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -63,9 +63,11 @@ class Alias(Verb):
     def _clone(self) -> tuple[Verb, dict[AstNode, AstNode], dict[UUID, UUID]]:
         cloned, nd_map, uuid_map = Verb._clone(self)
         if self.uuid_map is not None:  # happens if and only if keep_col_refs=False
-            assert len(self.uuid_map) == len(uuid_map)
+            assert set(self.uuid_map.keys()).issubset(uuid_map.keys())
             uuid_map = {
-                self.uuid_map[old_uid]: new_uid for old_uid, new_uid in uuid_map.items()
+                self.uuid_map[old_uid]: new_uid
+                for old_uid, new_uid in uuid_map.items()
+                if old_uid in self.uuid_map
             }
             cloned.uuid_map = None
         return cloned, nd_map, uuid_map

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -180,7 +180,6 @@ class Join(Verb):
     how: Literal["inner", "left", "full"]
     validate: Literal["1:1", "1:m", "m:1", "m:m"]
     suffix: str
-    coalesce: bool
 
     def _clone(self) -> tuple[Join, dict[AstNode, AstNode], dict[UUID, UUID]]:
         child, nd_map, uuid_map = self.child._clone()

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -60,6 +60,16 @@ class Verb(AstNode):
 class Alias(Verb):
     uuid_map: dict[UUID, UUID] | None
 
+    def _clone(self) -> tuple[Verb, dict[AstNode, AstNode], dict[UUID, UUID]]:
+        cloned, nd_map, uuid_map = Verb._clone(self)
+        if self.uuid_map is not None:  # happens if and only if keep_col_refs=False
+            assert len(self.uuid_map) == len(uuid_map)
+            uuid_map = {
+                self.uuid_map[old_uid]: new_uid for old_uid, new_uid in uuid_map.items()
+            }
+            cloned.uuid_map = None
+        return cloned, nd_map, uuid_map
+
 
 @dataclasses.dataclass(eq=False, slots=True)
 class Select(Verb):

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -57,7 +57,8 @@ class Verb(AstNode):
 
 
 @dataclasses.dataclass(eq=False, slots=True)
-class Alias(Verb): ...
+class Alias(Verb):
+    uuid_map: dict[UUID, UUID] | None
 
 
 @dataclasses.dataclass(eq=False, slots=True)

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -25,7 +25,13 @@ class Verb(AstNode):
 
         cloned.map_col_nodes(
             lambda col: Col(
-                col.name, nd_map[col._ast], uuid_map[col._uuid], col._dtype, col._ftype
+                col.name,
+                # If the current ast is not in nd_map (happens after collect with
+                # keep_col_refs=True), the node wasn't really present anyway.
+                nd_map.get(col._ast, col._ast),
+                uuid_map[col._uuid],
+                col._dtype,
+                col._ftype,
             )
             if isinstance(col, Col)
             else copy.copy(col)
@@ -205,7 +211,11 @@ class Join(Verb):
         cloned.right = right_child
         cloned.on = self.on.map_subtree(
             lambda col: Col(
-                col.name, nd_map[col._ast], uuid_map[col._uuid], col._dtype, col._ftype
+                col.name,
+                nd_map.get(col._ast, col._ast),
+                uuid_map[col._uuid],
+                col._dtype,
+                col._ftype,
             )
             if isinstance(col, Col)
             else copy.copy(col)

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -59,7 +59,6 @@ class Verb(AstNode):
 @dataclasses.dataclass(eq=False, slots=True)
 class Alias(Verb):
     uuid_map: dict[UUID, UUID] | None
-    subquery: bool = False
 
     def _clone(self) -> tuple[Verb, dict[AstNode, AstNode], dict[UUID, UUID]]:
         cloned, nd_map, uuid_map = Verb._clone(self)
@@ -231,3 +230,6 @@ class Join(Verb):
 
     def map_col_roots(self, g: Callable[[ColExpr], ColExpr]):
         self.on = g(self.on)
+
+
+class SubqueryMarker(Verb): ...

--- a/src/pydiverse/transform/_internal/tree/verbs.py
+++ b/src/pydiverse/transform/_internal/tree/verbs.py
@@ -59,6 +59,7 @@ class Verb(AstNode):
 @dataclasses.dataclass(eq=False, slots=True)
 class Alias(Verb):
     uuid_map: dict[UUID, UUID] | None
+    subquery: bool = False
 
     def _clone(self) -> tuple[Verb, dict[AstNode, AstNode], dict[UUID, UUID]]:
         cloned, nd_map, uuid_map = Verb._clone(self)

--- a/src/pydiverse/transform/common.py
+++ b/src/pydiverse/transform/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ._internal.backend.targets import DuckDb, Pandas, Polars, SqlAlchemy
+from ._internal.backend.targets import DuckDb, Pandas, Polars, Scalar, SqlAlchemy
 from ._internal.pipe.pipeable import verb
 from ._internal.pipe.verbs import (
     arrange,
@@ -41,4 +41,5 @@ __all__ = __base + [
     "SqlAlchemy",
     "Polars",
     "Pandas",
+    "Scalar",
 ]

--- a/src/pydiverse/transform/errors.py
+++ b/src/pydiverse/transform/errors.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
-from ._internal.errors import FunctionTypeError, NotSupportedError, SubqueryError
+from ._internal.errors import (
+    ColumnNotFoundError,
+    FunctionTypeError,
+    NotSupportedError,
+    SubqueryError,
+)
 
-__all__ = ["SubqueryError", "FunctionTypeError", "NotSupportedError"]
+__all__ = [
+    "SubqueryError",
+    "FunctionTypeError",
+    "NotSupportedError",
+    "ColumnNotFoundError",
+]

--- a/tests/test_backend_equivalence/conftest.py
+++ b/tests/test_backend_equivalence/conftest.py
@@ -290,7 +290,7 @@ def generate_df_fixtures():
         @pytest.fixture(scope="function")
         def table_fixture(request):
             df = dataframes[table_name]
-            name = f"equiv_{table_name}"
+            name = table_name
 
             table_x = BACKEND_TABLES[request.param[0]](df, name)
             table_y = BACKEND_TABLES[request.param[1]](df, name)

--- a/tests/test_backend_equivalence/conftest.py
+++ b/tests/test_backend_equivalence/conftest.py
@@ -113,6 +113,7 @@ dataframes = {
                 "11",
                 "$&/)",
             ],
+            "gb": ["a", "b", "a", "a", "0", "", "", "a", "", "c", "d", "b"],
         }
     ),
     "df_datetime": pl.DataFrame(

--- a/tests/test_backend_equivalence/test_filter.py
+++ b/tests/test_backend_equivalence/test_filter.py
@@ -5,9 +5,7 @@ from tests.util import assert_result_equal
 
 
 def test_noop(df2):
-    assert_result_equal(
-        df2, lambda t: t >> filter(), may_throw=True, exception=TypeError
-    )
+    assert_result_equal(df2, lambda t: t >> filter())
     assert_result_equal(df2, lambda t: t >> filter(t.col1 == t.col1))
 
 

--- a/tests/test_backend_equivalence/test_group_by.py
+++ b/tests/test_backend_equivalence/test_group_by.py
@@ -98,3 +98,9 @@ def test_group_by_bool_col(df4):
         >> group_by(C.x)
         >> mutate(y=C.col4.mean()),
     )
+
+
+def test_group_by_scalar(df3):
+    assert_result_equal(
+        df3, lambda t: t >> mutate(x=0) >> group_by(C.x) >> summarize(y=t.col1.sum())
+    )

--- a/tests/test_backend_equivalence/test_group_by.py
+++ b/tests/test_backend_equivalence/test_group_by.py
@@ -110,6 +110,7 @@ def test_group_by_scalar(df3):
         lambda t: t
         >> mutate(x=0)
         >> mutate(y=C.x.sum(partition_by=t.col2))
-        >> group_by(C.y)
-        >> summarize(z=t.col1.min()),
+        >> group_by(C.y)  # TODO: first alias and then group by should also work
+        >> alias()
+        >> summarize(z=C.col1.min()),
     )

--- a/tests/test_backend_equivalence/test_group_by.py
+++ b/tests/test_backend_equivalence/test_group_by.py
@@ -104,3 +104,12 @@ def test_group_by_scalar(df3):
     assert_result_equal(
         df3, lambda t: t >> mutate(x=0) >> group_by(C.x) >> summarize(y=t.col1.sum())
     )
+
+    assert_result_equal(
+        df3,
+        lambda t: t
+        >> mutate(x=0)
+        >> mutate(y=C.x.sum(partition_by=t.col2))
+        >> group_by(C.y)
+        >> summarize(z=t.col1.min()),
+    )

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -36,11 +36,6 @@ def test_join(df1, df2, how):
 
     assert_result_equal(
         (df1, df2),
-        lambda t, u: t >> join(u, on="col1", how=how, coalesce=True),
-    )
-
-    assert_result_equal(
-        (df1, df2),
         lambda t, u: t
         >> join(u, on=["col1", t.col1.cast(pdt.Float64()) >= u.col3], how=how),
     )

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -164,6 +164,10 @@ def test_ineq_join(df3, df4, df_strings):
         ),
     )
 
+    assert_result_equal(
+        (df3, df4), lambda s, t: s >> inner_join(t, on=["col1", s.col2 <= t.col2])
+    )
+
 
 def test_join_summarize(df3, df4):
     assert_result_equal(
@@ -201,3 +205,7 @@ def test_join_const_col(df3, df4):
         >> mutate(z=C.x + C.y)
         >> full_join(t_ := t >> alias(), on=t.col1 == t_.col2),
     )
+
+
+def test_cross_join(df2, df3):
+    assert_result_equal((df2, df3), lambda s, t: s >> cross_join(t))

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -192,6 +192,7 @@ def test_join_summarize(df3, df4):
         (df3, df4),
         lambda t3, t4: t3
         >> summarize(y=t3.col1.max(), z=t3.col4.mean())
+        >> alias()
         >> left_join(t4, on=C.y == t4.col4),
     )
 

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -238,7 +238,11 @@ def test_join_where(df2, df3, df4):
         (df3, df4),
         lambda t3, t4: t3
         >> filter(t3.col1 % 2 == 0)
-        >> full_join(t4 >> filter(t4.col1.is_not_null()), on=t3.col2 == t4.col2),
+        >> alias()
+        >> full_join(
+            t4_filtered := t4 >> filter(t4.col1.is_not_null()) >> alias(),
+            on=C.col2 == t4_filtered.col2,
+        ),
     )
 
 

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -234,12 +234,16 @@ def test_join_where(df2, df3, df4):
 
 def test_join_const_col(df3, df4):
     assert_result_equal(
-        (df3, df4), lambda s, t: s >> left_join(t >> mutate(y=0), on="col1")
+        (df3, df4),
+        lambda s, t: s >> left_join(t >> mutate(y=0) >> alias(), on=s.col1 == C.y_df4),
     )
 
     assert_result_equal(
         (df3, df4),
-        lambda s, t: s >> mutate(z=2) >> full_join(t >> mutate(j=True), on="col2"),
+        lambda s, t: s
+        >> mutate(z=2)
+        >> alias()
+        >> full_join(t >> mutate(j=True) >> alias(), on="col2"),
     )
 
     assert_result_equal(
@@ -247,7 +251,8 @@ def test_join_const_col(df3, df4):
         lambda t: t
         >> mutate(x=4, y=5)
         >> mutate(z=C.x + C.y)
-        >> full_join(t_ := t >> alias(), on=t.col1 == t_.col2),
+        >> alias()
+        >> full_join(t_ := t >> alias(), on=C.col1 == t_.col2),
     )
 
 

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -187,6 +187,50 @@ def test_join_summarize(df3, df4):
         ),
     )
 
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t3
+        >> summarize(y=t3.col1.max(), z=t3.col4.mean())
+        >> left_join(t4, on=C.y == t4.col4),
+    )
+
+
+def test_join_window(df3, df4):
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t3
+        >> mutate(y=t3.col1.dense_rank())
+        >> inner_join(t4, on=C.y == t4.col1),
+    )
+
+    assert_result_equal(
+        (df3, df4),
+        lambda s, t: s
+        >> mutate(y=s.col1.shift(1, arrange=s.col4))
+        >> inner_join(t, on="col2"),
+    )
+
+
+def test_join_where(df2, df3, df4):
+    assert_result_equal(
+        (df2, df3),
+        lambda t2, t3: t2 >> left_join(t3 >> filter(t3.col4 >= 2), on="col1"),
+    )
+
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t3
+        >> filter(t3.col4 != -1729)
+        >> left_join(t4 >> filter(t4.col3 > 0), on=t3.col2 == t4.col2),
+    )
+
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t3
+        >> filter(t3.col1 % 2 == 0)
+        >> full_join(t4 >> filter(t4.col1.is_not_null()), on=t3.col2 == t4.col2),
+    )
+
 
 def test_join_const_col(df3, df4):
     assert_result_equal(

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -168,3 +168,22 @@ def test_ineq_join(df3, df4, df_strings):
             & (s.col4 >= pdt.when(t.col1.str.starts_with(" ")).then(10).otherwise(7)),
         ),
     )
+
+
+def test_join_summarize(df3, df4):
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t3
+        >> group_by(t3.col2)
+        >> summarize(j=t3.col4.sum())
+        >> alias()
+        >> inner_join(t4, on="col2"),
+    )
+
+    assert_result_equal(
+        (df3, df4),
+        lambda t3, t4: t4
+        >> left_join(
+            t3 >> group_by(t3.col2) >> summarize(j=t3.col4.sum()) >> alias(), on="col2"
+        ),
+    )

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -182,3 +182,22 @@ def test_join_summarize(df3, df4):
             t3 >> group_by(t3.col2) >> summarize(j=t3.col4.sum()) >> alias(), on="col2"
         ),
     )
+
+
+def test_join_const_col(df3, df4):
+    assert_result_equal(
+        (df3, df4), lambda s, t: s >> left_join(t >> mutate(y=0), on="col1")
+    )
+
+    assert_result_equal(
+        (df3, df4),
+        lambda s, t: s >> mutate(z=2) >> full_join(t >> mutate(j=True), on="col2"),
+    )
+
+    assert_result_equal(
+        df3,
+        lambda t: t
+        >> mutate(x=4, y=5)
+        >> mutate(z=C.x + C.y)
+        >> full_join(t_ := t >> alias(), on=t.col1 == t_.col2),
+    )

--- a/tests/test_backend_equivalence/test_join.py
+++ b/tests/test_backend_equivalence/test_join.py
@@ -38,12 +38,6 @@ def test_join(df1, df2, how):
     assert_result_equal(
         (df1, df2),
         lambda t, u: t
-        >> join(u, on=["col1", t.col1.cast(pdt.Float64()) >= u.col3], how=how),
-    )
-
-    assert_result_equal(
-        (df1, df2),
-        lambda t, u: t
         >> join(u, (t.col1 == u.col1) & (t.col1 == u.col2), how=how)
         >> mutate(l=t.col2.str.len())
         >> left_join(v := u >> alias("v"), v.col2 == C.l)

--- a/tests/test_backend_equivalence/test_mutate.py
+++ b/tests/test_backend_equivalence/test_mutate.py
@@ -41,7 +41,7 @@ def test_literals(df1):
 
 # probably something wrong with pl.read_database (it goes via pandas). Maybe this
 # works once polars has a native solution.
-@skip_backends("msssql")
+@skip_backends("mssql")
 def test_float_lit(df1):
     assert_result_equal(df1, lambda t: t >> mutate(x=1.1))
 

--- a/tests/test_backend_equivalence/test_mutate.py
+++ b/tests/test_backend_equivalence/test_mutate.py
@@ -6,6 +6,7 @@ from pydiverse.transform._internal.pipe.verbs import (
     mutate,
     select,
 )
+from tests.fixtures.backend import skip_backends
 from tests.util import assert_result_equal
 
 
@@ -33,10 +34,16 @@ def test_reorder(df2):
 
 def test_literals(df1):
     assert_result_equal(df1, lambda t: t >> mutate(x=1))
-    assert_result_equal(df1, lambda t: t >> mutate(x=1.1))
     assert_result_equal(df1, lambda t: t >> mutate(x=True))
     assert_result_equal(df1, lambda t: t >> mutate(x="test"))
     assert_result_equal(df1, lambda t: t >> mutate(u=pdt.lit(None)))
+
+
+# probably something wrong with pl.read_database (it goes via pandas). Maybe this
+# works once polars has a native solution.
+@skip_backends("msssql")
+def test_float_lit(df1):
+    assert_result_equal(df1, lambda t: t >> mutate(x=1.1))
 
 
 def test_empty(df1):

--- a/tests/test_backend_equivalence/test_ops/test_case_expression.py
+++ b/tests/test_backend_equivalence/test_ops/test_case_expression.py
@@ -106,13 +106,13 @@ def test_summarize_case(df4):
             C.col1,
         )
         >> summarize(
-            x=C.col2.max().map(
-                {
-                    0: C.col1.min(),
-                    1: C.col2.mean() + 0.5,
-                    2: 2,
-                }
-            ),
+            # x=C.col2.max().map(
+            #     {
+            #         0: C.col1.min(),
+            #         1: C.col2.mean() + 0.5,
+            #         2: 2,
+            #     }
+            # ),
             y=pdt.when(C.col2.max() > 2)
             .then(1)
             .when(C.col2.max() < 2)

--- a/tests/test_backend_equivalence/test_ops/test_case_expression.py
+++ b/tests/test_backend_equivalence/test_ops/test_case_expression.py
@@ -106,13 +106,13 @@ def test_summarize_case(df4):
             C.col1,
         )
         >> summarize(
-            # x=C.col2.max().map(
-            #     {
-            #         0: C.col1.min(),
-            #         1: C.col2.mean() + 0.5,
-            #         2: 2,
-            #     }
-            # ),
+            x=C.col2.max().map(
+                {
+                    0: C.col1.min(),
+                    1: C.col2.mean() + 0.5,
+                    2: 2,
+                }
+            ),
             y=pdt.when(C.col2.max() > 2)
             .then(1)
             .when(C.col2.max() < 2)

--- a/tests/test_backend_equivalence/test_ops/test_functions.py
+++ b/tests/test_backend_equivalence/test_ops/test_functions.py
@@ -83,8 +83,8 @@ def test_sum(df4):
         df4,
         lambda t: t
         >> mutate(
-            w=pdt.min(*(c for c in t if c.dtype() <= pdt.Int())),
-            u=pdt.sum(*(c for c in t if c.dtype() <= pdt.Int())),
+            w=pdt.min(*(c for c in t if c.dtype().is_int())),
+            u=pdt.sum(*(c for c in t if c.dtype().is_int())),
             h=pdt.sum(t.col1 * t.col4, t.col5.str.len() * 2, t.col2 - t.col1),
         ),
     )
@@ -97,6 +97,5 @@ def test_coalesce(df4):
 
     assert_result_equal(
         df4,
-        lambda t: t
-        >> mutate(w=pdt.coalesce(*(c for c in t if c.dtype() <= pdt.Int()))),
+        lambda t: t >> mutate(w=pdt.coalesce(*(c for c in t if c.dtype().is_int()))),
     )

--- a/tests/test_backend_equivalence/test_ops/test_ops_bool.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_bool.py
@@ -18,3 +18,26 @@ def test_xor(df_bool):
 
 def test_invert(df_bool):
     assert_result_equal(df_bool, lambda t: t >> mutate(y=~t.a))
+
+
+def test_any_all(df_bool):
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.b) >> summarize(y=t.a.any()))
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.b) >> summarize(y=t.a.all()))
+
+
+def test_bool_comparison(df_bool):
+    assert_result_equal(df_bool, lambda t: t >> mutate(y=t.a < t.b))
+    assert_result_equal(df_bool, lambda t: t >> mutate(y=t.a > t.b))
+    assert_result_equal(df_bool, lambda t: t >> mutate(y=t.a <= t.b))
+    assert_result_equal(df_bool, lambda t: t >> mutate(y=t.a >= t.b))
+
+
+def test_bool_min_max(df_bool):
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.b) >> summarize(y=t.a.min()))
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.b) >> summarize(y=t.a.max()))
+
+
+def test_bool_sum(df_bool):
+    assert_result_equal(df_bool, lambda t: t >> mutate(y=t.a + t.b))
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.b) >> summarize(y=t.a.sum()))
+    assert_result_equal(df_bool, lambda t: t >> group_by(t.a) >> summarize(y=t.b.sum()))

--- a/tests/test_backend_equivalence/test_ops/test_ops_list.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_list.py
@@ -16,6 +16,18 @@ def test_list_agg(df3):
         check_row_order=True,
     )
 
+    assert_result_equal(
+        df3,
+        lambda t: t
+        >> group_by(t.col2)
+        >> summarize(
+            y=t.col5.list.agg(arrange=t.col4),
+            z=t.col4.list.agg(filter=t.col1 > 0, arrange=[t.col4.descending()]),
+        )
+        >> arrange(t.col2),
+        check_row_order=True,
+    )
+
 
 # to make this work, use array(SELECT col5 FROM t ORDER BY col1)
 # we can implement this with SELECT scalar

--- a/tests/test_backend_equivalence/test_ops/test_ops_list.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_list.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydiverse.transform.extended import *
+from tests.fixtures.backend import skip_backends
+from tests.util.assertion import assert_result_equal
+
+
+@skip_backends("mssql", "sqlite")
+def test_list_agg(df3):
+    assert_result_equal(
+        df3,
+        lambda t: t
+        >> group_by(t.col3)
+        >> summarize(s=t.col2.list.agg())
+        >> arrange(C.s),
+        check_row_order=True,
+    )
+
+
+@skip_backends("mssql", "sqlite")
+def test_list_agg_no_grouping(df3):
+    assert_result_equal(
+        df3,
+        lambda t: t >> summarize(h=t.col5.list.agg(arrange=t.col1)),
+        check_row_order=True,
+    )

--- a/tests/test_backend_equivalence/test_ops/test_ops_list.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_list.py
@@ -29,12 +29,11 @@ def test_list_agg(df3):
     )
 
 
-# to make this work, use array(SELECT col5 FROM t ORDER BY col1)
-# we can implement this with SELECT scalar
 @skip_backends("mssql", "sqlite")
 def test_list_agg_no_grouping(df3):
     assert_result_equal(
         df3,
-        lambda t: t >> summarize(h=t.col5.list.agg(arrange=t.col1)),
+        lambda t: t
+        >> summarize(h=t.col5.list.agg(arrange=[t.col1, t.col4.descending()])),
         check_row_order=True,
     )

--- a/tests/test_backend_equivalence/test_ops/test_ops_list.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_list.py
@@ -17,6 +17,8 @@ def test_list_agg(df3):
     )
 
 
+# to make this work, use array(SELECT col5 FROM t ORDER BY col1)
+# we can implement this with SELECT scalar
 @skip_backends("mssql", "sqlite")
 def test_list_agg_no_grouping(df3):
     assert_result_equal(

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -161,10 +161,19 @@ def test_str_join(df_strings):
         df_strings, lambda t: t >> group_by(t.e) >> summarize(con=t.c.str.join(", "))
     )
 
+    assert_result_equal(
+        df_strings,
+        lambda t: t >> group_by(t.gb) >> summarize(y=t.col1.str.join(arrange=t.col2)),
+    )
+
 
 def test_str_arrange(df_strings):
     def bind(col):
-        assert_result_equal(df_strings, lambda t: t >> arrange(t[col].nulls_last()))
+        assert_result_equal(
+            df_strings,
+            lambda t: t >> arrange(t[col].nulls_last(), t.c.nulls_last()),
+            check_row_order=True,
+        )
 
     for col in ["col1", "col2", "c", "d", "e", "gb"]:
         bind(col)

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -158,7 +158,12 @@ def test_slice(df_strings):
 
 def test_str_join(df_strings):
     assert_result_equal(
-        df_strings, lambda t: t >> group_by(t.e) >> summarize(con=t.c.str.join(", "))
+        df_strings,
+        lambda t: t
+        >> group_by(t.e)
+        >> summarize(
+            con=t.c.str.join(", ", arrange=[t.d.nulls_first(), t.c.nulls_last()])
+        ),
     )
 
     assert_result_equal(

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -160,3 +160,11 @@ def test_str_join(df_strings):
     assert_result_equal(
         df_strings, lambda t: t >> group_by(t.e) >> summarize(con=t.c.str.join(", "))
     )
+
+
+def test_str_arrange(df_strings):
+    def bind(col):
+        assert_result_equal(df_strings, lambda t: t >> arrange(t[col].nulls_last()))
+
+    for col in ["col1", "col2", "c", "d", "e", "gb"]:
+        bind(col)

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pydiverse.transform.extended import *
+from tests.fixtures.backend import skip_backends
 from tests.util import assert_result_equal
 
 
@@ -172,6 +173,7 @@ def test_str_join(df_strings):
     )
 
 
+@skip_backends("mssql")
 def test_str_arrange(df_strings):
     def bind(col):
         assert_result_equal(

--- a/tests/test_backend_equivalence/test_rename.py
+++ b/tests/test_backend_equivalence/test_rename.py
@@ -7,9 +7,7 @@ from tests.util import assert_result_equal
 
 
 def test_noop(df3):
-    assert_result_equal(
-        df3, lambda t: t >> rename({}), may_throw=True, exception=TypeError
-    )
+    assert_result_equal(df3, lambda t: t >> rename({}))
     assert_result_equal(df3, lambda t: t >> rename({"col1": "col1"}))
 
 

--- a/tests/test_backend_equivalence/test_slice_head.py
+++ b/tests/test_backend_equivalence/test_slice_head.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pydiverse.transform as pdt
+from pydiverse.transform.errors import ColumnNotFoundError
 from pydiverse.transform.extended import *
 from tests.util import assert_result_equal
 
@@ -75,7 +76,7 @@ def test_with_join(df1, df2):
         lambda t, u: t
         >> left_join(u >> arrange(*t) >> slice_head(2, offset=1), t.col1 == u.col1),
         check_row_order=False,
-        exception=ValueError,
+        exception=ColumnNotFoundError,
         may_throw=True,
     )
 

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -11,6 +11,7 @@ def test_ungrouped(df3):
         df3,
         lambda t: t >> summarize(mean3=t.col3.mean(), mean4=t.col4.mean()),
     )
+    assert_result_equal(df3, lambda t: t >> group_by() >> summarize(y=t.col1.sum()))
 
 
 def test_empty_ungrouped_fail(df3):
@@ -147,12 +148,6 @@ def test_not_summarising(df4):
 
 def test_none(df4):
     assert_result_equal(df4, lambda t: t >> summarize(x=None))
-
-
-# TODO: Implement more test cases for summarize verb
-
-
-# Test specific operations
 
 
 def test_op_min(df4):

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -109,16 +109,16 @@ def test_filter_argument(df3):
         >> summarize(u=t.col4.sum(filter=(t.col1 != 0))),
     )
 
-    # assert_result_equal(
-    #     df3,
-    #     lambda t: t
-    #     >> group_by(t.col4, t.col1)
-    #     >> summarize(
-    #         u=(t.col3 * t.col4 - t.col2).sum(
-    #             filter=(t.col5.is_in("a", "e", "i", "o", "u"))
-    #         )
-    #     ),
-    # )
+    assert_result_equal(
+        df3,
+        lambda t: t
+        >> group_by(t.col4, t.col1)
+        >> summarize(
+            u=(t.col3 * t.col4 - t.col2).sum(
+                filter=(t.col5.is_in("a", "e", "i", "o", "u"))
+            )
+        ),
+    )
 
 
 def test_arrange(df3):

--- a/tests/test_backend_equivalence/test_summarize.py
+++ b/tests/test_backend_equivalence/test_summarize.py
@@ -50,7 +50,7 @@ def test_chained_summarized(df3):
         >> mutate(k=(C.col1 + C.col2) * C.col4)
         >> group_by(C.k)
         >> summarize(x=C.col4.mean())
-        >> alias()  # TODO: I think we could prevent a subquery here.
+        >> alias()
         >> summarize(y=C.k.mean()),
     )
 

--- a/tests/test_backend_equivalence/test_syntax.py
+++ b/tests/test_backend_equivalence/test_syntax.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from pydiverse.transform import C
-from pydiverse.transform._internal.pipe.verbs import (
-    mutate,
-    select,
-)
+from pydiverse.transform._internal.errors import ColumnNotFoundError
+from pydiverse.transform._internal.pipe.verbs import mutate, select
 from tests.util import assert_result_equal
 
 
 def test_lambda_cols(df3):
     assert_result_equal(df3, lambda t: t >> select(C.col1, C.col2))
     assert_result_equal(df3, lambda t: t >> mutate(col1=C.col1, col2=C.col1))
-    assert_result_equal(df3, lambda t: t >> select(C.col10), exception=ValueError)
+    assert_result_equal(
+        df3, lambda t: t >> select(C.col10), exception=ColumnNotFoundError
+    )

--- a/tests/test_backend_equivalence/test_window_function.py
+++ b/tests/test_backend_equivalence/test_window_function.py
@@ -379,3 +379,9 @@ def test_op_dense_rank(df3):
             ),
         ),
     )
+
+
+def test_partition_by_const_col(df3):
+    assert_result_equal(
+        df3, lambda t: t >> mutate(x=0) >> mutate(y=t.col3.sum(partition_by=C.x))
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 import pydiverse.transform as pdt
+from pydiverse.transform._internal.errors import ColumnNotFoundError
 from pydiverse.transform._internal.pipe.pipeable import Pipeable, inverse_partial
 from pydiverse.transform.common import *
 
@@ -24,7 +25,7 @@ class TestTable:
         assert tbl1.col1.name == "col1"
         assert tbl1.col2._ast == tbl1._ast
 
-        with pytest.raises(ValueError, match="colXXX"):
+        with pytest.raises(ColumnNotFoundError, match="colXXX"):
             _ = tbl1.colXXX
 
     def test_getitem(self, tbl1):

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -652,6 +652,9 @@ class TestPolarsLazyImpl:
         with pytest.raises(ColumnNotFoundError):
             tbl1 >> select() >> collect() >> mutate(x=tbl1.col1)
 
+    def test_scalar_export(self):
+        assert (pdt.Table({"a": 1}) >> export(pdt.Scalar)) == 1
+
 
 class TestPrintAndRepr:
     def test_table_str(self, tbl1):

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -412,7 +412,7 @@ class TestPolarsLazyImpl:
             >> mutate(x=tbl3.col1.shift(1, arrange=tbl3.col4))
             >> inner_join(tbl4, on="col1"),
             df3.sort(pl.col("col4"))
-            .with_columns(x=pl.col("col3").shift(1))
+            .with_columns(x=pl.col("col1").shift(1))
             .join(df4, on="col1", suffix="_df4", coalesce=False),
         )
 

--- a/tests/util/assertion.py
+++ b/tests/util/assertion.py
@@ -92,8 +92,8 @@ def assert_result_equal(
                 pl.col(pl.Decimal(scale=10)).cast(pl.Float64)
             )
 
-            # after a join, cols containing only null values get type Null on SQLite and
-            # Postgres. maybe we can fix this but for now we just ignore such cols
+            # TODO: after a join, cols containing only null values get type Null on
+            # SQLite and Postgres. maybe we can fix this but for now we just ignore them
             assert dfx.columns == dfy.columns
             null_cols = set(dfx.select(pl.col(pl.Null)).columns) | set(
                 dfy.select(pl.col(pl.Null)).columns


### PR DESCRIPTION
pydiverse.transform now builds on pydiverse.common for the type system.

As for column operations and other features, we now have
- bool min / max / sum / addition
- full joins with filter and window functions in join conditions 
- export to pdt.Scalar
- string and list aggregation
- correct constant column handling in SQL