### PR TITLE
Bring AST repr closer to the real transform syntax

### DIFF
--- a/src/pydiverse/transform/_internal/backend/duckdb_polars.py
+++ b/src/pydiverse/transform/_internal/backend/duckdb_polars.py
@@ -43,8 +43,8 @@ class DuckDbPolarsImpl(TableImpl):
             ),
         )
 
-    def _ast_node_repr(self, expr_depth: int = -1) -> str:
-        return f"name = `{self.name}`\ndf = {repr(self.df)}\n"
+    def _table_def_repr(self) -> str:
+        return f"Table(df, DuckDb(), name='{self.name}')"
 
     @staticmethod
     def build_query(nd: AstNode) -> str | None:

--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -136,7 +136,7 @@ def convert_order_list(order_list: list[Order]) -> list[Order]:
         # workaround if nulls_last is None (i.e. the user doesn't care)
         if ord.nulls_last is not None and (ord.nulls_last ^ ord.descending):
             new_list.append(
-                Order(
+                Order.from_col_expr(
                     CaseExpr(
                         [(ord.order_by.is_null(), LiteralCol(int(ord.nulls_last)))],
                         LiteralCol(int(not ord.nulls_last)),

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -57,7 +57,7 @@ class PolarsImpl(TableImpl):
         )
 
     def _ast_node_repr(self, expr_depth: int = -1) -> str:
-        return f"name = '{self.name}',\ndf = {repr(self.df)}\n"
+        return f"PolarsImpl('{self.name}')"
 
     @staticmethod
     def build_query(nd: AstNode) -> None:

--- a/src/pydiverse/transform/_internal/backend/polars.py
+++ b/src/pydiverse/transform/_internal/backend/polars.py
@@ -56,8 +56,8 @@ class PolarsImpl(TableImpl):
             },
         )
 
-    def _ast_node_repr(self, expr_depth: int = -1) -> str:
-        return f"PolarsImpl('{self.name}')"
+    def _table_def_repr(self) -> str:
+        return f"Table(df, Polars(), name='{self.name}')"
 
     @staticmethod
     def build_query(nd: AstNode) -> None:

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -133,10 +133,8 @@ class SqlImpl(TableImpl):
             {col.name: self.pdt_type(col.type) for col in self.table.columns},
         )
 
-    def _ast_node_repr(self, expr_depth: int = -1) -> str:
-        return (
-            self.__class__.__name__ + f"('{self.name}', engine = {repr(self.engine)})"
-        )
+    def _table_def_repr(self) -> str:
+        return f"Table('{self.name}', SqlAlchemy({self.engine.url}))"
 
     def col_names(self) -> list[str]:
         return [col.name for col in self.table.columns]

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -134,7 +134,7 @@ class SqlImpl(TableImpl):
         )
 
     def _table_def_repr(self) -> str:
-        return f"Table('{self.name}', SqlAlchemy({self.engine.url}))"
+        return f"Table('{self.name}', SqlAlchemy('{self.engine.url}'))"
 
     def col_names(self) -> list[str]:
         return [col.name for col in self.table.columns]

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -134,7 +134,9 @@ class SqlImpl(TableImpl):
         )
 
     def _ast_node_repr(self, expr_depth: int = -1) -> str:
-        return f"name = `{self.name}`\nengine = {repr(self.engine)}\n"
+        return (
+            self.__class__.__name__ + f"('{self.name}', engine = {repr(self.engine)})"
+        )
 
     def col_names(self) -> list[str]:
         return [col.name for col in self.table.columns]

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -41,14 +41,20 @@ class TableImpl(AstNode):
         }
 
     def _unformatted_ast_repr(
-        self, verb_depth: int = -1, expr_depth: int = -1, oneline: bool = False
+        self, verb_depth: int, expr_depth: int, display_name_map
     ) -> str:
-        if oneline:
-            return self.__class__.__name__ + (
-                f"('{self.name}')" if self.name is not None else ""
-            )
+        return self._ast_node_repr(expr_depth, display_name_map)
 
-        return self._ast_node_repr(expr_depth)
+    def _ast_node_repr(self, expr_depth, display_name_map):
+        return display_name_map[self]
+
+    def _table_def_repr(self) -> str:
+        raise NotImplementedError()
+
+    def short_name(self):
+        return (
+            "?" if self.name is None else self.name
+        ) + f" (source table, backend: '{self.backend_name}')"
 
     def __init_subclass__(cls) -> None:
         cls.impl_store = ImplStore()

--- a/src/pydiverse/transform/_internal/backend/table_impl.py
+++ b/src/pydiverse/transform/_internal/backend/table_impl.py
@@ -3,7 +3,6 @@
 
 import functools
 import operator
-import textwrap
 import uuid
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
@@ -41,15 +40,15 @@ class TableImpl(AstNode):
             for name, dtype in schema.items()
         }
 
-    def ast_repr(
+    def _unformatted_ast_repr(
         self, verb_depth: int = -1, expr_depth: int = -1, oneline: bool = False
     ) -> str:
         if oneline:
             return self.__class__.__name__ + (
                 f"('{self.name}')" if self.name is not None else ""
             )
-        nd_repr = self._ast_node_repr(expr_depth)
-        return f"* {self.__class__.__name__}\n" + textwrap.indent(nd_repr, "| ")
+
+        return self._ast_node_repr(expr_depth)
 
     def __init_subclass__(cls) -> None:
         cls.impl_store = ImplStore()

--- a/src/pydiverse/transform/_internal/pipe/cache.py
+++ b/src/pydiverse/transform/_internal/pipe/cache.py
@@ -51,7 +51,7 @@ class Cache:
             + ",\n"
             + f"  partition_by={self.partition_by}\n"
             + "  derived_from={"
-            + f"{', '.join(d.ast_repr(oneline=True) for d in self.derived_from)}"
+            + f"{', '.join(d.short_name() for d in self.derived_from)}"
             + "},\n"
             + "  cols={"
             + f"""{
@@ -345,7 +345,7 @@ def transfer_col_references(table, ref_source):
     in the `mutate`. (Of course, you would normally have a SQL backend when
     materializing, not a polars backend like in the example here.)
     """
-    from pydiverse.transform._internal.pipe.table import Table, get_print_tbl_name
+    from pydiverse.transform._internal.pipe.table import Table
     from pydiverse.transform._internal.tree.verbs import Alias
 
     errors.check_arg_type(Table, "transfer_col_references", "table", table)
@@ -355,9 +355,9 @@ def transfer_col_references(table, ref_source):
         col := next((col for col in table if col.name not in ref_source), None)
     ) is not None:
         raise ValueError(
-            f"column {col.ast_repr()} of the table `{get_print_tbl_name(table)}` does "
+            f"column {col.ast_repr()} of the table `{table._ast.short_name()}` does "
             "not exist in the reference source table "
-            f"`{get_print_tbl_name(ref_source)}`"
+            f"`{ref_source._ast.short_name()}`"
         )
 
     new = copy.copy(table)

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -180,7 +180,7 @@ class Table:
             if key._uuid not in self._cache.uuid_to_name:
                 raise ColumnNotFoundError(
                     f"column `{key.ast_repr()}` does not exist in table "
-                    f"`{get_print_tbl_name(self)}`"
+                    f"`{self._ast.short_name()}`"
                 )
             return Col(
                 self._cache.uuid_to_name[key._uuid],
@@ -197,7 +197,7 @@ class Table:
             raise AttributeError
         if name not in self._cache.name_to_uuid:
             raise ColumnNotFoundError(
-                f"column `{name}` does not exist in table `{get_print_tbl_name(self)}`"
+                f"column `{name}` does not exist in table `{self._ast.short_name()}`"
             )
         col = self._cache.cols[self._cache.name_to_uuid[name]]
         return Col(name, self._ast, col._uuid, col._dtype, col._ftype)
@@ -352,11 +352,3 @@ def is_sql_backed(table: Table) -> bool:
     Whether the table has a SQL backend.
     """
     return table._cache.backend not in ("polars", "duckdb_polars")
-
-
-def get_print_tbl_name(table: Table | AstNode) -> str:
-    if isinstance(table, Table):
-        table = table._ast
-    if (nm := table.name) is None:
-        return table.__class__.__name__ + "(...)"
-    return nm

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -39,7 +39,7 @@ from pydiverse.transform._internal.pipe.pipeable import (
     modify_ast,
     verb,
 )
-from pydiverse.transform._internal.pipe.table import Table, get_print_tbl_name
+from pydiverse.transform._internal.pipe.table import Table
 from pydiverse.transform._internal.tree import types
 from pydiverse.transform._internal.tree.col_expr import (
     Col,
@@ -406,8 +406,8 @@ def show_query(table: Table, pipe: bool = False) -> Pipeable | None:
         print(query)
     else:
         print(
-            f"No query to show for table {get_print_tbl_name(table)}. "
-            f"(backend: {get_backend(table._ast).backend_name})"
+            f"No query to show for table {table._ast.short_name()}. "
+            f"(backend: {table._cache.backend})"
         )
 
     return table if pipe else None
@@ -449,7 +449,7 @@ def select(table: Table, *cols: Col | ColName | str) -> Pipeable:
         if isinstance(col, ColName | str) and col not in table:
             raise ColumnNotFoundError(
                 f"column `{col.ast_repr()}` does not exist in table "
-                f"`{get_print_tbl_name(table)}`"
+                f"`{table._ast.short_name()}`"
             )
         elif col not in table and col._uuid in table._cache.cols:
             raise ColumnNotFoundError(
@@ -601,7 +601,7 @@ def rename(table: Table, name_map: dict[str | Col | ColName, str]) -> Pipeable:
     if d := set(name_map).difference(table._cache.name_to_uuid):
         raise ValueError(
             f"no column with name `{next(iter(d))}` in table "
-            f"`{get_print_tbl_name(table)}`"
+            f"`{table._ast.short_name()}`"
         )
 
     if d := (set(table._cache.name_to_uuid).difference(name_map)) & set(
@@ -1159,9 +1159,9 @@ def join(
         raise TypeError("cannot join two tables with different backends")
 
     if left._cache.partition_by:
-        raise ValueError(f"cannot join grouped table `{get_print_tbl_name(left)}`")
+        raise ValueError(f"cannot join grouped table `{left._ast.short_name()}`")
     elif right._cache.partition_by:
-        raise ValueError(f"cannot join grouped table `{get_print_tbl_name(right)}`")
+        raise ValueError(f"cannot join grouped table `{right._ast.short_name()}`")
 
     if intersection := left._cache.derived_from & right._cache.derived_from:
         raise ValueError(
@@ -1204,9 +1204,9 @@ def join(
         ):
             raise ValueError(
                 f"column `{expr.ast_repr()}` used in `on` neither exists in the table "
-                f"`{get_print_tbl_name(left)}` nor in the table "
-                f"`{get_print_tbl_name(right)}`. The source table "
-                f"`{get_print_tbl_name(expr._ast)}` of the column must be an "
+                f"`{left._ast.short_name()}` nor in the table "
+                f"`{right._ast.short_name()}`. The source table "
+                f"`{expr._ast.short_name()}` of the column must be an "
                 "ancestor of one of the two input tables."
             )
 

--- a/src/pydiverse/transform/_internal/pipe/verbs.py
+++ b/src/pydiverse/transform/_internal/pipe/verbs.py
@@ -1454,7 +1454,7 @@ def columns(table: Table) -> list[str]:
 
 @overload
 def ast_repr(
-    verb_depth: int = -1, expr_depth: int = -1, pipe: bool = False
+    verb_depth: int = 7, expr_depth: int = 2, pipe: bool = False
 ) -> Pipeable | None: ...
 
 

--- a/src/pydiverse/transform/_internal/tree/ast.py
+++ b/src/pydiverse/transform/_internal/tree/ast.py
@@ -26,6 +26,7 @@ class AstNode:
     def __repr__(self) -> str:
         return self.short_name()
 
+    # Formatted, almost source code like representation of the AST.
     def ast_repr(self, verb_depth: int = -1, expr_depth: int = -1) -> str:
         from pydiverse.transform._internal.backend.table_impl import TableImpl
         from pydiverse.transform._internal.tree.col_expr import Col
@@ -113,8 +114,10 @@ class AstNode:
     def short_name(self) -> str:
         raise NotImplementedError()
 
+    # Recursive, builds up the verb chain.
     def _unformatted_ast_repr(self, verb_depth: int, expr_depth: int, display_name_map):
         raise NotImplementedError()
 
+    # Just the verb call of a single verb, without `>>`.
     def _ast_node_repr(self, expr_depth: int, display_name_map):
         raise NotImplementedError()

--- a/src/pydiverse/transform/_internal/tree/ast.py
+++ b/src/pydiverse/transform/_internal/tree/ast.py
@@ -1,6 +1,7 @@
 # Copyright (c) QuantCo and pydiverse contributors 2025-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
+import subprocess
 from collections.abc import Iterable
 from uuid import UUID
 
@@ -26,6 +27,29 @@ class AstNode:
 
     def ast_repr(
         self, verb_depth: int = -1, expr_depth: int = -1, *, oneline: bool = False
-    ) -> str: ...
+    ) -> str:
+        unformatted = (
+            "("
+            + self._unformatted_ast_repr(verb_depth, expr_depth, oneline=oneline)
+            + ")"
+        )
+        try:
+            proc = subprocess.run(
+                ["ruff", "format", "-"],  # '-' tells Ruff to read from stdin
+                input=unformatted.encode(),
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(unformatted)
+            print(e.stderr.decode())
+            raise e
+        return proc.stdout.decode()
 
-    def _ast_node_repr(self, expr_depth: int): ...
+    def _unformatted_ast_repr(
+        self, verb_depth: int = -1, expr_depth: int = -1, *, oneline: bool
+    ):
+        raise NotImplementedError()
+
+    def _ast_node_repr(self, expr_depth: int):
+        raise NotImplementedError()

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2769,7 +2769,7 @@ class EvalAligned(ColExpr):
         return (
             "eval_aligned("
             f"{self.val._ast_repr(depth - 1, False)},"
-            f"with_={self.with_.ast_repr(oneline=True) if self.with_ else None})"
+            f"with_={self.with_.short_name() if self.with_ else None})"
         )
 
 

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2712,7 +2712,7 @@ class Cast(ColExpr):
                         "the expression."
                     )
 
-                raise TypeError(
+                raise DataTypeError(
                     f"cannot cast type {self.val.dtype()} to {self.target_type}.{hint}",
                     source=self._fn_id,
                 )

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -125,10 +125,15 @@ class ColExpr(Generic[T]):
     def _repr_pretty_(self, p, cycle):
         p.text(str(self) if not cycle else "...")
 
+    # User exposed ast_repr function
     def ast_repr(self, depth: int = -1) -> str:
         return self._ast_repr(depth, False, dict())
 
-    def _ast_repr(self, depth: int, needs_parens: bool, table_display_name_map):
+    # Does the recursive calls and allows to alter the displayed names of the tables
+    # of columns (this is necessary for the verb ast_repr).
+    def _ast_repr(
+        self, depth: int, needs_parens: bool, table_display_name_map: dict[AstNode, str]
+    ):
         raise NotImplementedError()
 
     def export(self, target: Target) -> pl.Series | pd.Series:

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -3020,4 +3020,4 @@ def get_ast_path_str(tree_root: ColExpr, error_source: UUID | ColExpr) -> str:
         if any(nd is path[-1] for nd in node.iter_children()):
             path.append(node)
 
-    return "  --->  ".join(nd.ast_repr(depth=0) for nd in reversed(path))
+    return "  --->  ".join(nd.ast_repr(depth=1) for nd in reversed(path))

--- a/src/pydiverse/transform/_internal/tree/col_expr.py
+++ b/src/pydiverse/transform/_internal/tree/col_expr.py
@@ -2339,6 +2339,10 @@ class ColFn(ColExpr):
                 return parenthesize(f"...{op_symbol}...")
             if op_symbol := DUNDER_UNARY.get(self.op.name):
                 return parenthesize(f"{op_symbol}(...)")
+            if not self.op.generate_expr_method:
+                # This is for the functions defined in the `functions.py` module, which
+                # are called like pdt.<fn name>(...)
+                return f"{self.op.name}(...)"
 
             return f"(...).{self.op.name}" + (
                 "(...)" if len(self.args) > 1 or len(self.context_kwargs) > 0 else "()"
@@ -2360,9 +2364,11 @@ class ColFn(ColExpr):
         if op_symbol := DUNDER_BINARY.get(self.op.name):
             assert len(args) == 2
             return parenthesize(f"{args[0]} {op_symbol} {args[1]}")
-        elif op_symbol := DUNDER_UNARY.get(self.op.name):
+        if op_symbol := DUNDER_UNARY.get(self.op.name):
             assert len(args) == 1
             return parenthesize(f"{op_symbol}{args[0]}")
+        if not self.op.generate_expr_method:
+            return f"{self.op.name}" + "(" + ", ".join(args) + ")"
 
         return f"{args[0]}.{self.op.name}" + "(" + ", ".join(args[1:]) + ")"
 

--- a/tests/test_polars_table.py
+++ b/tests/test_polars_table.py
@@ -921,3 +921,30 @@ class TestPrintAndRepr:
             >> summarize(u=pdt.when(intermed.col1.max() >= 2).then(None).otherwise(4))
             >> ast_repr(verb_depth=-1, expr_depth=-1)
         )
+
+        series = pl.Series([2**i for i in range(12)])
+
+        assert (
+            "tbl__1729.j"
+            in (
+                tbl3
+                >> mutate(
+                    u=C.col1 + 5,
+                    v=(tbl3.col2.exp() + tbl3.col4) * tbl3.col1,
+                    w=pdt.max(tbl3.col2, tbl3.col1, tbl3.col5.str.len()),
+                    x=pdt.count(),
+                    y=eval_aligned(
+                        (
+                            tbl3
+                            >> mutate(j=42)
+                            >> alias("tbl. 1729")
+                            >> filter(C.col2 > 0)
+                        ).j
+                        + tbl3.col1
+                    ),
+                    z=eval_aligned(series),
+                )
+                >> select(tbl3.col1, tbl3.col4)
+                >> left_join(tbl4, on="col1")
+            )._ast.ast_repr()
+        )


### PR DESCRIPTION
- The representation is always to be understood with the following imports (We don't print them, I think this would be too pedantic):
```python
from pydiverse.transform import Table
from pydiverse.transform.extended import *
```
- If a table name is not a valid python identifier, AST printing in this form may fail. (We handle spaces, dots and hyphens by replacing them with underscores)
- To get from the printed AST repr to running source code, one needs to
  - fix the table definitions and fill them with actual data
  - Sometimes break the flow and introduce variables for aliases