### PR TITLE
Fix repr(Table) for group-by expressions

### DIFF
--- a/src/pydiverse/transform/_internal/backend/mssql.py
+++ b/src/pydiverse/transform/_internal/backend/mssql.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/src/pydiverse/transform/_internal/backend/sql.py
+++ b/src/pydiverse/transform/_internal/backend/sql.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import dataclasses

--- a/src/pydiverse/transform/_internal/pipe/table.py
+++ b/src/pydiverse/transform/_internal/pipe/table.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import inspect
@@ -314,8 +314,9 @@ class Table:
 
 def get_head_tail(tbl: Table) -> tuple[pl.DataFrame, int]:
     import pydiverse.transform as pdt
-    from pydiverse.transform._internal.pipe.verbs import export, slice_head, summarize
+    from pydiverse.transform._internal.pipe.verbs import export, slice_head, summarize, ungroup
 
+    tbl = tbl >> ungroup()
     height = tbl >> summarize(num_rows=pdt.count()) >> export(pdt.Scalar)
     tbl_rows = int(pl.Config.state().get("POLARS_FMT_MAX_ROWS") or 10)
     if height <= tbl_rows:

--- a/tests/test_backend_equivalence/test_ops/test_ops_string.py
+++ b/tests/test_backend_equivalence/test_ops/test_ops_string.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from pydiverse.transform.extended import *

--- a/tests/test_backend_equivalence/test_print.py
+++ b/tests/test_backend_equivalence/test_print.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from pydiverse.transform.extended import *

--- a/tests/test_sql_table.py
+++ b/tests/test_sql_table.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo and pydiverse contributors 2025-2025
+# Copyright (c) QuantCo and pydiverse contributors 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import polars as pl


### PR DESCRIPTION
## Summary
- Fixes `repr(pdt.Table)` crashing with `TypeError` when the table has a `group_by` applied.
- The issue was in `get_head_tail()`: calling `summarize(num_rows=pdt.count())` on a grouped table produces the group-by columns plus `num_rows`, then `export(pdt.Scalar)` fails because it expects exactly one column.
- The fix ungroups the table at the start of `get_head_tail` before summarizing and exporting.

Closes #96

## Reproducer
```python
import pydiverse.transform as pdt
from pydiverse.transform import C

tbl = pdt.Table({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
grouped = tbl >> pdt.group_by(C.a, C.b)
repr(grouped)  # was: TypeError, now prints the table correctly
```

## Test plan
- [x] Verified the error reproduces on `main`
- [x] Verified `repr()` works after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)